### PR TITLE
Ignore variant list separator.

### DIFF
--- a/scss/mixins.scss
+++ b/scss/mixins.scss
@@ -40,7 +40,7 @@ $_o-brand-depth: () !default; // The number of current variant parts by componen
     @each $key, $value in $variables {
         // Sort brand variant key.
         @if type-of($value) == 'map' {
-            $key: _oBrandQuickSort($key);
+            $key: _oBrandNormaliseVariant($key);
         }
         // Merge variable/variant map.
         $sorted-variables: map-merge($sorted-variables, ($key: $value));
@@ -192,7 +192,7 @@ $_o-brand-depth: () !default; // The number of current variant parts by componen
     $variables: map-get($brand-config, 'variables');
     // Use variant variables if a variant is configured.
     $current-variant: _oBrandGetCurrentVariant($component);
-    $variant-variables: map-get($variables, _oBrandQuickSort($current-variant));
+    $variant-variables: map-get($variables, _oBrandNormaliseVariant($current-variant));
     @if type-of($variant-variables) == 'map' {
         $variables: $variant-variables;
     }
@@ -291,6 +291,29 @@ $_o-brand-depth: () !default; // The number of current variant parts by componen
         @return _oBrandGetConfig($component, $_o-brand-default);
     }
     @return $brand-config;
+}
+
+/**
+* Ensure variants are expressed consistently,
+* so they may be compared and matched.
+*
+* Only effects compound variants:
+* - Makes a variant list alphabetical.
+* - Makes a variant list have a comma list separator.
+*
+* @access private
+* @param {list|string} $variant The variant to normalise.
+* @return {list|string}
+**/
+@function _oBrandNormaliseVariant($variant) {
+    @if type-of($variant) != 'list' {
+        @return $variant;
+    }
+    // Compound variant is expressed in order.
+    $variant: _oBrandQuickSort($variant);
+    // List separator is consistent.
+    $variant: join($variant, (), 'comma');
+    @return $variant;
 }
 
 /**

--- a/test-scss/_mixins.test.scss
+++ b/test-scss/_mixins.test.scss
@@ -123,7 +123,7 @@
         }
     }
 
-    @include test('Gets a variable value for a configured variant, regardless of list seperator') {
+    @include test('Gets a variable value for a configured variant, regardless of list separator') {
         // space
         @include oBrandConfigureFor($component: 'o-example', $variant: ('b2b' 'inverse')) {
             $property: oBrandGet($component: 'o-example', $variables: 'example-background');

--- a/test-scss/_mixins.test.scss
+++ b/test-scss/_mixins.test.scss
@@ -123,6 +123,19 @@
         }
     }
 
+    @include test('Gets a variable value for a configured variant, regardless of list seperator') {
+        // space
+        @include oBrandConfigureFor($component: 'o-example', $variant: ('b2b' 'inverse')) {
+            $property: oBrandGet($component: 'o-example', $variables: 'example-background');
+            @include assert-equal($property, darkred);
+        }
+        // comma
+        @include oBrandConfigureFor($component: 'o-example', $variant: ('b2b', 'inverse')) {
+            $property: oBrandGet($component: 'o-example', $variables: 'example-background');
+            @include assert-equal($property, darkred);
+        }
+    }
+
     @include test('Gets a variable value for a configured compound variant (nested)') {
         @include oBrandConfigureFor($component: 'o-example', $variant: 'inverse') {
             // variant: inverse


### PR DESCRIPTION
Refer to tests.
https://github.com/Financial-Times/o-brand/pull/4/files#diff-86f8ea0e1b584e3a7badd71300afc986