### PR TITLE
Add `oBrandOverride` and update `oBrandGet`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ The following mixins and functions help brand a component.
 - [oBrandDefine](#defining-brand-configuration) - Define brand configuration (variables & settings).
 - [oBrandGet](#retrieve-a-variable) - Retrieve brand variables.
 - [oBrandConfigureFor](#retrieve-a-variable-for-a-variant) - Work with variants.
+- [oBrandOverride](#override-the-current-brand) - Override component configuration for the current brand.
 
 ### Defining Brand Configuration
 
@@ -178,6 +179,14 @@ Nesting is also supported:
 }
 ```
 
+A variable may also be retrieved for an explicit variant using the `$force-variant` argument of `oBrandGet`. This is useful when retrieving a variant value within a function, or when a specific value is needed regardless of what variant is current configured using `oBrandConfigureFor`.
+
+```scss
+	.o-example--inverse {
+		content: oBrandGet('o-example', 'component-content', $force-variant: 'inverse'); // "inverse" variant value
+	}
+```
+
 ### Output Styles Only If A Brand Supports A Variant
 
 Not all brands will share variants. Define support in the `settings` map as demonstrated above. To output styles only if the current brand supports the variant use `oBrandConfigureFor`.
@@ -205,6 +214,28 @@ Uses of `oBrandGet` within `oBrandConfigureFor` [retrieves a variable for a vari
 		// "extra b2b" compound variant is not supported.
 		content: '"extra b2b" variant not available for the current brand.';
 	}
+}
+```
+
+### Override The Current Brand
+
+It may be desirable to output a customised variant of a component based on the current brand. To do this create a mixin which maps arguments to `oBrandOverride`. This prevents brand configuration from becoming a public interface, which makes it possible to change brand variables at a later point without a breaking change.
+
+The following contrived example shows how to override brand variables:
+
+```scss
+@mixin oExample($background-color, $forground-color) {
+	$custom-config: ('variables', {
+		'example-background-color': $background-color,
+		'example-color': $forground-color,
+		'border-color': $forground-color,
+	});
+
+	@include oBrandOverride('example-background-color', $custom-config) {
+		background: oBrandGet('example-background-color');
+		color: oBrandGet('example-color');
+		border: 1px solid oBrandGet('border-color');
+	};
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ Nesting is also supported:
 }
 ```
 
-A variable may also be retrieved for an explicit variant using the `$force-variant` argument of `oBrandGet`. This is useful when retrieving a variant value within a function, or when a specific value is needed regardless of what variant is current configured using `oBrandConfigureFor`.
+A variable may also be retrieved for an explicit variant using the `$force-variant` argument of `oBrandGet`. This is useful when retrieving a variant value within a function, or when a specific value is needed regardless of what variant is configured by `oBrandConfigureFor`.
 
 ```scss
 	.o-example--inverse {
@@ -219,7 +219,7 @@ Uses of `oBrandGet` within `oBrandConfigureFor` [retrieves a variable for a vari
 
 ### Override The Current Brand
 
-It may be desirable to output a customised variant of a component based on the current brand. To do this create a mixin which maps arguments to `oBrandOverride`. This prevents brand configuration from becoming a public interface, which makes it possible to change brand variables at a later point without a breaking change.
+It may be desirable to output a customised variant of a component based on brand configuration. To do this create a component specific mixin which maps arguments to `oBrandOverride`. This prevents brand configuration from becoming a public interface, which makes it possible to change brand variables at a later point without a breaking change.
 
 The following contrived example shows how to override brand variables:
 

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ The following contrived example shows how to override brand variables:
 		'border-color': $forground-color,
 	});
 
-	@include oBrandOverride('example-background-color', $custom-config) {
+	@include oBrandOverride('o-example', $custom-config) {
 		background: oBrandGet('example-background-color');
 		color: oBrandGet('example-color');
 		border: 1px solid oBrandGet('border-color');

--- a/README.md
+++ b/README.md
@@ -228,13 +228,13 @@ The following contrived example shows how to override brand variables:
 	$custom-config: ('variables', {
 		'example-background-color': $background-color,
 		'example-color': $forground-color,
-		'border-color': $forground-color,
+		'example-border-color': $forground-color,
 	});
 
 	@include oBrandOverride('o-example', $custom-config) {
 		background: oBrandGet('example-background-color');
 		color: oBrandGet('example-color');
-		border: 1px solid oBrandGet('border-color');
+		border: 1px solid oBrandGet('example-border-color');
 	};
 }
 ```

--- a/scss/mixins.scss
+++ b/scss/mixins.scss
@@ -88,8 +88,8 @@ $_o-brand-depth: () !default; // The number of current variant parts by componen
         @error 'The default brand "#{$_o-brand-default}" must be defined for "#{$component}" before using o-brand.';
     }
     // Validate variant.
-    @if type-of($variant) != 'list' and type-of($variant) != 'string' {
-        @error 'Cound not configure for variant #{type-of($variant)} "#{$variant}", expecting a list or string.';
+    @if type-of($variant) != 'list' and type-of($variant) != 'string' and type-of($variant) != 'null' {
+        @error 'Cound not configure for variant "#{$variant}" of type "#{type-of($variant)}", expecting a list or string.';
     }
     // Add to current variant to output variant content.
     @include _oBrandAddToCurrentVariant($component, $variant);
@@ -157,7 +157,7 @@ $_o-brand-depth: () !default; // The number of current variant parts by componen
 **/
 @function _oBrandSupports($component, $variant) {
     // Validate variant.
-    @if type-of($variant) != 'list' and type-of($variant) != 'string' {
+    @if type-of($variant) != 'list' and type-of($variant) != 'string' and type-of($variant) != 'null' {
         @error 'Cound not check support for variant #{type-of($variant)} "#{$variant}", expecting a list or string.';
     }
     // Get all brand settings, which are used to indicate variant support.

--- a/scss/mixins.scss
+++ b/scss/mixins.scss
@@ -517,15 +517,13 @@ $_o-brand-depth: () !default; // The number of current variant parts by componen
         @each $key, $value in $map2 {
             @if (type-of(map-get($result, $key)) == map and type-of($value) == map) {
                 $result: map-merge($result, ($key: _oBrandRecursiveMapMerge(map-get($result, $key), $value)));
-            }
-            @else {
+            } @else {
                 $result: map-merge($result, ($key: $value));
             }
         }
         @return $result;
-    }
-    @else {
-        @warn '_oBrandRecursiveMapMerge() expects it\'s parameters to be map types!';
+    } @else {
+        @warn '_oBrandRecursiveMapMerge() expects it\'s parameters to be of type "map".';
         @return null;
     }
 }

--- a/scss/mixins.scss
+++ b/scss/mixins.scss
@@ -111,19 +111,20 @@ $_o-brand-depth: () !default; // The number of current variant parts by componen
 * @access public
 * @param {string} $component
 * @param {string | list} $variables
+* @param {string | list} $force-variant Get a variable for a specific variant, disregard any configured variant (`oBrandConfigureFor`).
 * @return {string | number | color | null}
 **/
-@function oBrandGet($component, $variables) {
+@function oBrandGet($component, $variables, $force-variant: null) {
     // For one variable return value.
 
     @if length($variables) == 1 {
-        @return _oBrandGetVariableValue($component, nth($variables, 1));
+        @return _oBrandGetVariableValue($component, nth($variables, 1), $force-variant);
     }
     // Concatenate multiple requested variables for use in one property.
     $values: ();
     @each $variable in $variables {
         @if $variable {
-            $values: join($values,  _oBrandGetVariableValue($component, $variable));
+            $values: join($values,  _oBrandGetVariableValue($component, $variable, $force-variant));
         }
     }
     @return $values;
@@ -185,14 +186,18 @@ $_o-brand-depth: () !default; // The number of current variant parts by componen
 * @access private
 * @param {string} $component
 * @param {string} $variable
+* @param {string | list} $force-variant Get a variable for a specific variant, disregard any configured variant (`oBrandConfigureFor`).
 * @return {string | number | color | null}
 **/
-@function _oBrandGetVariableValue($component, $variable) {
+@function _oBrandGetVariableValue($component, $variable, $force-variant: null) {
     // Get all brand variables.
     $brand-config: _oBrandGetConfig($component, $o-brand);
     $variables: map-get($brand-config, 'variables');
     // Use variant variables if a variant is configured.
-    $current-variant: _oBrandGetCurrentVariant($component);
+    @if $force-variant and not (type-of($force-variant) == 'list' or type-of($force-variant) == 'string') {
+        @error 'Could not get get variable "#{$variable}" for component "#{$component}" and variant "#{$force-variant}", the variant should be of type string or list but was "#{type-of($force-variant)}".';
+    }
+    $current-variant: if($force-variant, $force-variant, _oBrandGetCurrentVariant($component));
     $variant-variables: map-get($variables, _oBrandNormaliseVariant($current-variant));
     @if type-of($variant-variables) == 'map' {
         $variables: $variant-variables;

--- a/scss/mixins.scss
+++ b/scss/mixins.scss
@@ -14,47 +14,17 @@ $_o-brand-depth: () !default; // The number of current variant parts by componen
 * @param {map} $config
 **/
 @mixin oBrandDefine($component, $brand, $config) {
-    // Validate input.
     @if type-of($component) != 'string' or $component == '' {
         @error 'Could not set brand "#{$brand}" for component "#{$component}". A component name of type string must be given.';
     }
     @if type-of($brand) != 'string' or $brand == '' {
         @error 'Could not set brand "#{$brand}" for component "#{$component}". A brand of type string must be given.';
     }
-    @if type-of($config) != 'map' {
-        @error 'Could not set brand "#{$brand}", it\'s configuration must be a map.';
+    @if _oBrandIsDefined($component, $brand) {
+        @error 'Brand "#{$brand}" is already defined for component "#{$component}".';
     }
-    // Validate brand variables and settings.
-    $variables: map-get($config, 'variables');
-    $settings: map-get($config, 'settings');
-    $errorMessage: 'Could not set brand "#{$brand}".';
-    @if $variables and (type-of($variables) != 'map' and type-of($variables) != 'list' ) {
-        @error $errorMessage + ' Config key "variables" should be a map but is of type #{type-of($variables)}.';
-    }
-    @if $settings and (type-of($settings) != 'map' and type-of($settings) != 'list' ) {
-        @error $errorMessage + ' Config key "settings" should be a map but is of type #{type-of($settings)}.';
-    }
-    // Sort and merge variant config.
-    // In brand variables maps are considered variant config, where the key is the variant.
-    // Brand variants could be defined twice e.g. ('a', 'b', 'c'): (background: red), ('c', 'a', 'b'): (background: red).
-    $sorted-variables: ();
-    @each $key, $value in $variables {
-        // Sort brand variant key.
-        @if type-of($value) == 'map' {
-            $key: _oBrandNormaliseVariant($key);
-        }
-        // Merge variable/variant map.
-        $sorted-variables: map-merge($sorted-variables, ($key: $value));
-    }
-    // Create an updated component brands map.
-    $component-brands: map-get($_o-brands, $component);
-    $component-brands: if(type-of($component-brands) == 'map', $component-brands, ());
-    $component-brands: map-merge($component-brands, ($brand: (
-        'variables': $sorted-variables,
-        'settings': $settings
-    )));
-    // Add updated component brands map to global brands object.
-    $_o-brands: map-merge($_o-brands, ($component: $component-brands)) !global;
+    // Define brand configuration.
+    $result: _oBrandUpdateConfig($component, $brand, $config);
 }
 
 /**
@@ -84,7 +54,7 @@ $_o-brand-depth: () !default; // The number of current variant parts by componen
 **/
 @mixin oBrandConfigureFor($component, $variant) {
     // The default brand must be configured before o-brand can be used.
-    @if not _oBrandIsDefaultConfigured($component) {
+    @if not _oBrandIsDefined($component) {
         @error 'The default brand "#{$_o-brand-default}" must be defined for "#{$component}" before using o-brand.';
     }
     // Validate variant.
@@ -98,6 +68,32 @@ $_o-brand-depth: () !default; // The number of current variant parts by componen
     }
     // Variant content output. Remove from the current variant so future CSS is not effected.
     @include _oBrandRemoveFromCurrentVariant($component, $variant);
+}
+
+/**
+* Override component configuration for the current brand.
+* Configuration override applies to the mixin content block.
+*
+* @access public
+* @param {string} $component
+* @param {map} $config
+**/
+@mixin oBrandOverride($component, $config) {
+    $current-depth: _oBrandGetCurrentDepth($component);
+    @if($current-depth > 0) {
+        @error '`oBrandOverride` must wrap any `oBrandConfigureFor` call. Brand config cannot be overriden within a `oBrandConfigureFor` content block.';
+    }
+    @if type-of($config) != 'map' {
+        @error 'Could not override component "#{$component}" for brand "#{$brand}", the override configuration must be a map.';
+    }
+    // Get original config.
+    $brand: if($o-brand, $o-brand, $o-brand-default);
+    $original-config: _oBrandGetConfig($component, $brand);
+    // Override config.
+    $result: _oBrandUpdateConfig($component, $brand, $config);
+    @content;
+    // Remove override. Back to original config.
+    $result: _oBrandRestoreConfig($component, $brand, $original-config);
 }
 
 /**
@@ -131,17 +127,92 @@ $_o-brand-depth: () !default; // The number of current variant parts by componen
 }
 
 /**
-* Check the default brand is configured. Otherwise using o-brand is not allowed.
+* Sets config for a given component and brand.
+*
+* @access private
+* @param {string} $component
+* @param {string} $brand
+* @param {map} $config
+* @return {map}
+**/
+@function _oBrandRestoreConfig($component, $brand, $config) {
+    $valid: _oBrandValidateConfig($component, $brand, $config);
+    $component-brands: map-get($_o-brands, $component);
+    $component-brands: map-merge($component-brands, ($brand: $config));
+    $_o-brands: map-merge($_o-brands, ($component: $component-brands)) !global;
+    @return $_o-brands;
+}
+
+/**
+* Updates config for a given component and brand using a recursive merge.
+*
+* @access private
+* @param {string} $component
+* @param {string} $brand
+* @param {map} $config
+* @return {map}
+**/
+@function _oBrandUpdateConfig($component, $brand, $config) {
+    // Validate config
+    $valid: _oBrandValidateConfig($component, $brand, $config);
+    $variables: map-get($config, 'variables');
+    $settings: map-get($config, 'settings');
+    // Ensure compound variant lists are alphabetical.
+    $sorted-variables: ();
+    @each $key, $value in $variables {
+        @if type-of($value) == 'map' {
+            $key: _oBrandNormaliseVariant($key);
+        }
+        $sorted-variables: map-merge($sorted-variables, ($key: $value));
+    }
+    // Update config.
+    $_o-brands: _oBrandRecursiveMapMerge($_o-brands, ($component: ($brand: (
+        'variables': $sorted-variables,
+        'settings': $settings
+    )))) !global;
+    @return $_o-brands;
+}
+
+/**
+* Validate config.
+*
+* @access private
+* @param {string} $component
+* @param {string} $brand
+* @param {map} $config
+* @return {map}
+**/
+@function _oBrandValidateConfig($component, $brand, $config) {
+    $errorMessage: '"#{$component}" configuration for brand "#{$brand}" is invalid';
+    @if type-of($config) != 'map' {
+        @error '#{$errorMessage}. Its configuration must be a map.';
+    }
+    // Validate brand variables and settings.
+    $variables: map-get($config, 'variables');
+    $settings: map-get($config, 'settings');
+    @if $variables and (type-of($variables) != 'map' and type-of($variables) != 'list' ) {
+        @error '#{$errorMessage}. Config key "variables" should be a map but is of type #{type-of($variables)}.';
+    }
+    @if $settings and (type-of($settings) != 'map' and type-of($settings) != 'list' ) {
+        @error '#{$errorMessage}. Config key "settings" should be a map but is of type #{type-of($settings)}.';
+    }
+    @return true;
+}
+
+/**
+* Check the brand is configured.
+* By default checks the default brand is configured.
 * The default brand must be configured by the component as it is the fallback.
 *
 * @access private
 * @param {string} $component
+* @param {string} $brand
 * @return {boolean}
 **/
-@function _oBrandIsDefaultConfigured($component) {
+@function _oBrandIsDefined($component, $brand: $_o-brand-default) {
     $component-brands: map-get($_o-brands, $component);
     $component-brands: if(type-of($component-brands) == 'map', $component-brands, ());
-    @return type-of(map-get($component-brands, $_o-brand-default)) == 'map';
+    @return type-of(map-get($component-brands, $brand)) == 'map';
 }
 
 /**
@@ -288,7 +359,7 @@ $_o-brand-depth: () !default; // The number of current variant parts by componen
     $component-brands: if(type-of($component-brands) == 'map', $component-brands, ());
     $brand-config: map-get($component-brands, $brand);
     // The default brand must be configured before o-brand can be used.
-    @if not _oBrandIsDefaultConfigured($component) {
+    @if not _oBrandIsDefined($component) {
         @error 'The default brand "#{$_o-brand-default}" must be defined for "#{$component}" before using o-brand.';
     }
     // Validate the requested brand is configured, fallback to the default brand otherwise.
@@ -433,4 +504,28 @@ $_o-brand-depth: () !default; // The number of current variant parts by componen
 
     @return str-length($string-a) < str-length($string-b);
     // sass-lint:enable variable-name-format
+}
+
+/// Merge config maps recursively.
+/// Keys in $map2 will take precedence over keys in $map1.
+///
+/// @acess private
+/// @link https://github.com/pentzzsolt/sass-recursive-map-merge/
+@function _oBrandRecursiveMapMerge($map1, $map2) {
+    @if ((type-of($map1) == map or type-of($map1) == list) and (type-of($map2) == map or type-of($map2) == list)) {
+        $result: $map1;
+        @each $key, $value in $map2 {
+            @if (type-of(map-get($result, $key)) == map and type-of($value) == map) {
+                $result: map-merge($result, ($key: _oBrandRecursiveMapMerge(map-get($result, $key), $value)));
+            }
+            @else {
+                $result: map-merge($result, ($key: $value));
+            }
+        }
+        @return $result;
+    }
+    @else {
+        @warn '_oBrandRecursiveMapMerge() expects it\'s parameters to be map types!';
+        @return null;
+    }
 }

--- a/test-scss/_mixins.test.scss
+++ b/test-scss/_mixins.test.scss
@@ -90,6 +90,31 @@
             }
         }
     }
+
+    @include test('Ignores null variants') {
+        @include oBrandConfigureFor($component: 'o-example', $variant: null) { // should have no effect
+            @include oBrandConfigureFor($component: 'o-example', $variant: 'inverse') {
+                @include oBrandConfigureFor($component: 'o-example', $variant: null) { // should have no effect
+                    // variant: inverse
+                    $property: oBrandGet($component: 'o-example', $variables: 'example-background');
+                    @include assert-equal($property, grey);
+                    // variant: inverse b2b
+                    @include oBrandConfigureFor($component: 'o-example', $variant: 'b2b') {
+                        @include oBrandConfigureFor($component: 'o-example', $variant: null) { // should have no effect
+                            $property: oBrandGet($component: 'o-example', $variables: 'example-background');
+                            @include assert-equal($property, darkred);
+                        }
+                    }
+                    // variant: inverse
+                    $property: oBrandGet($component: 'o-example', $variables: 'example-background');
+                    @include assert-equal($property, grey);
+                }
+            }
+        }
+        // variant: none
+        $property: oBrandGet($component: 'o-example', $variables: 'example-background');
+        @include assert-equal($property, white);
+    }
 }
 
 @include test-module('oBrandGet') {

--- a/test-scss/_mixins.test.scss
+++ b/test-scss/_mixins.test.scss
@@ -192,3 +192,76 @@
         }
     }
 }
+
+@include test-module('oBrandOverride') {
+    @include test('Overrides brand variable value') {
+        @include oBrandOverride($component: 'o-example', $config: ('variables': (
+                'example-background': blue
+            ))) {
+            $property: oBrandGet($component: 'o-example', $variables: 'example-background');
+            @include assert-equal($property, blue);
+        }
+    }
+
+    @include test('Overrides brand settings') {
+        @include assert('The "unsupported" variant is not supported by the test brand but is overriden and output') {
+            @include output {
+                @include oBrandOverride($component: 'o-example', $config: ('settings': (
+                    'unsupported': true
+                ))) {
+                    @include oBrandConfigureFor($component: 'o-example', $variant: 'unsupported') {
+                        content: '"unsupported" variant is not supported but is overriden';
+                    }
+                }
+            }
+            @include expect {
+                content: '"unsupported" variant is not supported but is overriden';
+            }
+        }
+
+        @include assert('The "b2b" variant is supported by the test brand but is overriden and should not be output') {
+            @include output {
+                @include oBrandOverride($component: 'o-example', $config: ('settings': (
+                    'b2b': false
+                ))) {
+                    @include oBrandConfigureFor($component: 'o-example', $variant: 'b2b') {
+                        content: '"b2b" variant supported but is overriden';
+                    }
+                }
+            }
+            @include expect {
+            }
+        }
+    }
+
+    @include test('Does not override default variable outside of the override content block') {
+        $overrides: ('variables': (
+                'example-override-weight': 'bold',
+                'example-background': blue
+        ));
+        @include oBrandOverride($component: 'o-example', $config: $overrides) {
+            $property: oBrandGet($component: 'o-example', $variables: 'example-background');
+            @include assert-equal($property, blue);
+        }
+        $property: oBrandGet($component: 'o-example', $variables: 'example-background');
+        // overriden variables should be back to normal outside the mixin content block
+        @include assert-equal($property, white);
+        // override specific variables should not be available outside the mixin content block
+        $property: oBrandGet($component: 'o-example', $variables: 'example-override-weight');
+        @include assert-equal($property, null);
+    }
+
+    @include test('Overrides variant configuration') {
+        $overrides: ('variables': (
+            'inverse': (
+                'example-background': purple
+            )
+        ));
+        @include oBrandOverride($component: 'o-example', $config: $overrides) {
+            @include oBrandConfigureFor($component: 'o-example', $variant: 'inverse') {
+                $property: oBrandGet($component: 'o-example', $variables: 'example-background');
+                @include assert-equal($property, purple);
+            }
+        }
+    }
+}

--- a/test-scss/_mixins.test.scss
+++ b/test-scss/_mixins.test.scss
@@ -176,4 +176,19 @@
             @include assert-equal($property, grey);
         }
     }
+
+    @include test('Gets a variable value for a "forced" variant') {
+        $property: oBrandGet($component: 'o-example', $variables: 'example-background', $force-variant: 'inverse');
+        @include assert-equal($property, grey);
+
+        $property: oBrandGet($component: 'o-example', $variables: 'example-background', $force-variant: ('inverse', 'b2b'));
+        @include assert-equal($property, darkred);
+    }
+
+    @include test('Gets a variable value for a "forced" variant, ignoring configured variants') {
+        @include oBrandConfigureFor($component: 'o-example', $variant: 'b2b') {
+            $property: oBrandGet($component: 'o-example', $variables: 'example-background', $force-variant: 'inverse');
+            @include assert-equal($property, grey);
+        }
+    }
 }


### PR DESCRIPTION
Adds `oBrandOverride` to override component configuration for the current brand.
Updates `oBrandGet` to explicitly retrieve a variant variable within a function (where it is not possible to use `oBrandConfigureFor`).

I'm following up with larger README changes based on @gvonkoss's feedback to make things easier to follow.