### PR TITLE
oBrandGet: No longer requires `$component` argument, now accepts config to override a defined brand.

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,26 +200,21 @@ $custom-config: (
 Building on the `oBrandDefine` example the following outputs multiple `o-example` variants with different backgrounds. The variants are only output if the brand supports them:
 
 ```scss
-
-@mixin oExampleTheme() {
-	background: oBrandGet($variables: 'example-background');
-}
-
 @include oBrandConfigureFor($component: 'o-example', $variant: 'inverse') {
 	.o-example--inverse {
-		@include oExampleTheme(); // background: paper;
+		background: oBrandGet($variables: 'example-background'); // background: paper;
 	}
 }
 
 @include oBrandConfigureFor($component: 'o-example', $variant: 'b2b') {
 	.o-example--b2b {
-		@include oExampleTheme(); // background: lightblue;
+		background: oBrandGet($variables: 'example-background'); // background: lightblue;
 	}
 }
 
 @include oBrandConfigureFor($component: 'o-example', $variant: ('b2b', 'inverse')) {
 	.o-example--b2b .o-example--inverse {
-		@include oExampleTheme(); // background: darkblue;
+		background: oBrandGet($variables: 'example-background'); // background: darkblue;
 	}
 }
 ```

--- a/README.md
+++ b/README.md
@@ -164,25 +164,26 @@ To request multiple variables at once, assuming variables `example-border-size: 
 }
 ```
 
-Retrieve a variable for a variant using `oBrandGet` using `$force-variant`. Whilst this is possible use [`oBrandConfigureFor`](#retrieve-a-variable-for-a-variant) instead where possible.
+Retrieve a variable for a variant using `oBrandGet` and `$configure-for`.
 ```scss
 .o-example--inverse {
-	background: oBrandGet($component: 'o-example', $variables: 'example-background', $force-variant: 'inverse'); // background: slate;
+	background: oBrandGet($component: 'o-example', $variables: 'example-background', $configure-for: 'inverse'); // background: slate;
 }
 ```
 
 - `oBrandGet` returns `null` if a variable is undefined. Sass removes css properties which are set to `null`. This is a useful feature to conditionally output css properties for different variants.
+- Whilst it is possible to get a brand variable for an explicit component and variant using `oBrandGet`, instead use [`oBrandConfigureFor`](#retrieve-a-variable-for-a-variant) where possible.
 
 ### oBrandConfigureFor
 
-`oBrandConfigureFor` improves working with variants. It accepts a Sass content block which will only output if the brand supports the given variant. It also configures all `oBrandGet` calls within its content block for a given variant.
+`oBrandConfigureFor` configures all `oBrandGet` calls within its content block for a given component and variant, which removes the need to repeatedly pass the component and variant to `oBrandGet`. In addition it will only output the sass content block if the component brand supports the given variant.
 
 Building on the `oBrandDefine` example the following outputs multiple `o-example` variants with different backgrounds. The variants are only output if the brand supports them:
 
 ```scss
 
 @mixin oExampleTheme() {
-	background: oBrandGet($component: 'o-example', $variables: 'example-background');
+	background: oBrandGet($variables: 'example-background');
 }
 
 @include oBrandConfigureFor($component: 'o-example', $variant: 'inverse') {
@@ -208,7 +209,7 @@ Building on the `oBrandDefine` example the following outputs multiple `o-example
 
 ```scss
 @mixin oExampleTheme() {
-	background: oBrandGet($component: 'o-example', $variables: 'example-background');
+	background: oBrandGet($variables: 'example-background');
 }
 
 // "b2b" variant
@@ -236,7 +237,7 @@ $custom-config: ('variables', {
 
 .o-example--custom-variant {
 	@include oBrandOverride('o-example', $custom-config) {
-		background: oBrandGet($component: 'o-example', $variables: 'example-background'); // background: hotpink
+		background: oBrandGet($variables: 'example-background'); // background: hotpink
 	};
 }
 ```

--- a/README.md
+++ b/README.md
@@ -45,10 +45,10 @@ Mixins within `o-brand` help configure components to support brands. There is no
 
 The following mixins and functions help brand a component.
 
-- [oBrandDefine](#obranddefine) - Defines brand configuration (variables & settings).
-- [oBrandGet](#obrandget) - Retrieves brand variables.
-- [oBrandConfigureFor](#obrandconfigurefor) - Supports working with variants.
-- [oBrandOverride](#obrandoverride) - Helps customise a defined brand.
+- [oBrandDefine](#obranddefine) - Define brand configuration (variables & settings).
+- [oBrandGet](#obrandget) - Retrieve brand variables.
+- [oBrandConfigureFor](#obrandconfigurefor) - Choose a variant and automatically configure `oBrandGet`.
+- [oBrandOverride](#obrandoverride) - Customise a defined brand to automatically override `oBrandGet`.
 
 ### oBrandDefine
 
@@ -171,7 +171,7 @@ Retrieve a variable for a variant using `oBrandGet` and `$configure-for`.
 }
 ```
 
-Override variables using `oBrandGet` and `$override`. The override paramater accepts configuration to override brand configuration set with `oBrandDefine`, it expects the same configuration format.
+Override variables using `oBrandGet` and `$override-config`. The override paramater accepts configuration to override brand configuration set with `oBrandDefine`, it expects the same configuration format.
 
 Assuming variables `example-background: 'paper'`, `example-border-size: 1px`, `example-border-type: solid`, `example-border-color: grey` are defined using `oBrandDefine`:
 
@@ -184,8 +184,8 @@ $custom-config: (
 );
 
 .o-example {
-	background: oBrandGet($component: 'o-example', $variables: 'example-background', $override: $custom-config); // background: hotpink;
-	border: oBrandGet($component: 'o-example', $variables: ('example-border-size', 'example-border-type', 'example-border-color'), $override: $custom-config); // border: 2px solid grey;
+	background: oBrandGet($component: 'o-example', $variables: 'example-background', $override-config: $custom-config); // background: hotpink;
+	border: oBrandGet($component: 'o-example', $variables: ('example-border-size', 'example-border-type', 'example-border-color'), $override-config: $custom-config); // border: 2px solid grey;
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -171,8 +171,27 @@ Retrieve a variable for a variant using `oBrandGet` and `$configure-for`.
 }
 ```
 
+Override variables using `oBrandGet` and `$override`. The override paramater accepts configuration to override brand configuration set with `oBrandDefine`, it expects the same configuration format.
+
+Assuming variables `example-background: 'paper'`, `example-border-size: 1px`, `example-border-type: solid`, `example-border-color: grey` are defined using `oBrandDefine`:
+
+```scss
+$custom-config: (
+	'variables': (
+		'example-background': 'hotpink',
+		'example-border-size', '2px'
+	)
+);
+
+.o-example {
+	background: oBrandGet($component: 'o-example', $variables: 'example-background', $override: $custom-config); // background: hotpink;
+	border: oBrandGet($component: 'o-example', $variables: ('example-border-size', 'example-border-type', 'example-border-color'), $override: $custom-config); // border: 2px solid grey;
+}
+```
+
 - `oBrandGet` returns `null` if a variable is undefined. Sass removes css properties which are set to `null`. This is a useful feature to conditionally output css properties for different variants.
-- Whilst it is possible to get a brand variable for an explicit component and variant using `oBrandGet`, instead use [`oBrandConfigureFor`](#retrieve-a-variable-for-a-variant) where possible.
+- Whilst it is possible to get a brand variable for an explicit component and variant using `oBrandGet`, instead use [`oBrandConfigureFor`](#obrandconfigurefor) where possible.
+- Whilst it is possible to override any defined variable using `oBrandGet`, instead use [`oBrandOverride`](#obrandoverride) where possible.
 
 ### oBrandConfigureFor
 

--- a/scss/mixins.scss
+++ b/scss/mixins.scss
@@ -4,6 +4,7 @@ $_o-brand-default: 'master'; // The fallback current brand. Allows us to check i
 $_o-brands: () !default; // A map of components to their defined brands.
 $_o-brand-current-component: null !default; // Currently configured component.
 $_o-brand-current-variant: null !default; // Currently configured variant.
+$_o-brand-current-override: null !default; // Currently configured brand config override.
 $_o-brand-default-not-set-warning: false !default; // Has the default not set warning been output.
 
 /// Define component configuration for a brand.
@@ -99,14 +100,12 @@ $_o-brand-default-not-set-warning: false !default; // Has the default not set wa
     }
     @include oBrandConfigureFor($component, $variant: null) {
         @if $config {
-            $brand: if($o-brand, $o-brand, $_o-brand-default);
-            // Get original config.
-            $original-config: _oBrandGetConfig($component, $brand);
-            // Override config.
-            $result: _oBrandUpdateConfig($component, $brand, $config);
+            // Set override.
+            $initial-override: $_o-brand-current-override;
+            $_o-brand-current-override: $config !global;
             @content;
-            // Remove override. Back to original config.
-            $result: _oBrandRestoreConfig($component, $brand, $original-config);
+            // Restore override.
+            $_o-brand-current-override: $initial-override !global;
         } @else {
             @content;
         }
@@ -125,21 +124,35 @@ $_o-brand-default-not-set-warning: false !default; // Has the default not set wa
 /// @param {string} $component
 /// @param {string | list} $variables
 /// @param {string | list} $configure-for Get a variable for a specific variant, disregard any configured variant (`oBrandConfigureFor`).
+/// @param {map} $override Configuration to override defined brand configuration. Expects the same as the `oBrandDefine` `$config` argument.
 /// @return {string | number | color | null}
-@function oBrandGet($variables, $component: $_o-brand-current-component, $configure-for: $_o-brand-current-variant) {
+@function oBrandGet($variables, $component: $_o-brand-current-component, $configure-for: $_o-brand-current-variant, $override: $_o-brand-current-override) {
     // For one variable return value.
     @if $component == null {
         @error 'Can not get variable "#{variables}" as the component is not configured. Use `oBrandConfigureFor` or pass a `$component` argument.';
     }
-    @if length($variables) == 1 {
-        @return _oBrandGetVariableValue($component, nth($variables, 1), $configure-for);
+    @if $override and type-of($override) != 'map' {
+        @error '`oBrandGet` expects "$override" to be of type map but was of type "#{type-of($override)}": "#{$override}".';
+    }
+    // Override config.
+    $brand: if($o-brand, $o-brand, $_o-brand-default);
+    $original-config: _oBrandGetConfig($component, $brand);
+    @if $override {
+        $result: _oBrandUpdateConfig($component, $brand, $override);
     }
     // Concatenate multiple requested variables for use in one property.
-    $values: ();
+    $values: null;
     @each $variable in $variables {
-        @if $variable {
-            $values: join($values,  _oBrandGetVariableValue($component, $variable, $configure-for));
+        $value: _oBrandGetVariableValue($component, $variable, $configure-for);
+        @if $values {
+            $values: join($values, $value);
+        } @else {
+            $values: $value;
         }
+    }
+    // Restore original config.
+    @if $override {
+        $result: _oBrandRestoreConfig($component, $brand, $original-config);
     }
     @return $values;
 }
@@ -264,15 +277,26 @@ $_o-brand-default-not-set-warning: false !default; // Has the default not set wa
 /// @access private
 /// @param {string} $component
 /// @param {string | list} $variant
+/// @param {map} $override
 /// @return {boolean}
-@function _oBrandSupports($component, $variant) {
+@function _oBrandSupports($component, $variant, $override: $_o-brand-current-override) {
     // Validate variant.
     @if type-of($variant) != 'list' and type-of($variant) != 'string' and type-of($variant) != 'null' {
         @error 'Cound not check support for variant #{type-of($variant)} "#{$variant}", expecting a list or string.';
     }
+    // Override config.
+    $brand: if($o-brand, $o-brand, $_o-brand-default);
+    $original-config: _oBrandGetConfig($component, $brand);
+    @if $override {
+        $result: _oBrandUpdateConfig($component, $brand, $override);
+    }
     // Get all brand settings, which are used to indicate variant support.
     $brand-config: _oBrandGetConfig($component, $o-brand);
     $brand-settings: map-get($brand-config, 'settings');
+    // Restore original config.
+    @if $override {
+        $result: _oBrandRestoreConfig($component, $brand, $original-config);
+    }
     // No settings are enabled so no variants are supported.
     @if type-of($brand-settings) != 'map' {
         @return false;

--- a/scss/mixins.scss
+++ b/scss/mixins.scss
@@ -124,21 +124,21 @@ $_o-brand-default-not-set-warning: false !default; // Has the default not set wa
 /// @param {string} $component
 /// @param {string | list} $variables
 /// @param {string | list} $configure-for Get a variable for a specific variant, disregard any configured variant (`oBrandConfigureFor`).
-/// @param {map} $override Configuration to override defined brand configuration. Expects the same as the `oBrandDefine` `$config` argument.
+/// @param {map} $override-config Configuration to override defined brand configuration. Expects the same as the `oBrandDefine` `$config` argument.
 /// @return {string | number | color | null}
-@function oBrandGet($variables, $component: $_o-brand-current-component, $configure-for: $_o-brand-current-variant, $override: $_o-brand-current-override) {
+@function oBrandGet($variables, $component: $_o-brand-current-component, $configure-for: $_o-brand-current-variant, $override-config: $_o-brand-current-override) {
     // For one variable return value.
     @if $component == null {
         @error 'Can not get variable "#{variables}" as the component is not configured. Use `oBrandConfigureFor` or pass a `$component` argument.';
     }
-    @if $override and type-of($override) != 'map' {
+    @if $override-config and type-of($override-config) != 'map' {
         @error '`oBrandGet` expects "$override" to be of type map but was of type "#{type-of($override)}": "#{$override}".';
     }
     // Override config.
     $brand: if($o-brand, $o-brand, $_o-brand-default);
     $original-config: _oBrandGetConfig($component, $brand);
-    @if $override {
-        $result: _oBrandUpdateConfig($component, $brand, $override);
+    @if $override-config {
+        $result: _oBrandUpdateConfig($component, $brand, $override-config);
     }
     // Concatenate multiple requested variables for use in one property.
     $values: null;
@@ -151,7 +151,7 @@ $_o-brand-default-not-set-warning: false !default; // Has the default not set wa
         }
     }
     // Restore original config.
-    @if $override {
+    @if $override-config {
         $result: _oBrandRestoreConfig($component, $brand, $original-config);
     }
     @return $values;

--- a/scss/mixins.scss
+++ b/scss/mixins.scss
@@ -2,8 +2,8 @@ $o-brand: null !default; // The chosen current brand.
 $o-brand-debug-mode: false !default; // Show extra (optional) warnings. E.g. value for variant not found.
 $_o-brand-default: 'master'; // The fallback current brand. Allows us to check if o-brand is set explicitly.
 $_o-brands: () !default; // A map of components to their defined brands.
-$_o-brand-variant: () !default; // Current variant by component.
-$_o-brand-depth: () !default; // The number of current variant parts by component.
+$_o-brand-current-component: null !default; // Currently configured component.
+$_o-brand-current-variant: null !default; // Currently configured variant.
 $_o-brand-default-not-set-warning: false !default; // Has the default not set warning been output.
 
 /// Define component configuration for a brand.
@@ -58,15 +58,18 @@ $_o-brand-default-not-set-warning: false !default; // Has the default not set wa
     @if type-of($variant) != 'list' and type-of($variant) != 'string' and type-of($variant) != 'null' {
         @error 'Cound not configure for variant "#{$variant}" of type "#{type-of($variant)}", expecting a list or string.';
     }
-    // Add to current variant to output variant content.
-    @include _oBrandAddToCurrentVariant($component, $variant);
-    @if not $variant or _oBrandSupports($component, _oBrandGetCurrentVariant($component)) {
+    // Log variant and component before updating.
+    $initial-variant: $_o-brand-current-variant;
+    $initial-component: $_o-brand-current-component;
+    // Update variant and component.
+    @include _oBrandUpdateCurrent($component, $variant);
+    // Configure and output content block.
+    @if not $variant or _oBrandSupports($component, $_o-brand-current-variant) {
         @content;
     }
-    // Variant content output. Remove from the current variant so future CSS is not effected.
-    @include _oBrandRemoveFromCurrentVariant($component, $variant);
+    // Reset variant and component.
+    @include _oBrandResetCurrent($initial-component, $initial-variant);
 }
-
 
 /// Override component configuration for the current brand.
 /// Configuration override applies to the mixin content block.
@@ -90,21 +93,23 @@ $_o-brand-default-not-set-warning: false !default; // Has the default not set wa
 /// @param {string} $component
 /// @param {map} $config
 @mixin oBrandOverride($component, $config) {
-    $current-depth: _oBrandGetCurrentDepth($component);
-    @if($current-depth > 0) {
-        @error '`oBrandOverride` must wrap any `oBrandConfigureFor` call. Brand config cannot be overriden within a `oBrandConfigureFor` content block.';
+    $variants-configured: if($_o-brand-current-variant, length($_o-brand-current-variant), 0);
+    @if($variants-configured > 0) {
+        @error '`oBrandOverride` must wrap any `oBrandConfigureFor` call. Brand config cannot be overriden within a `oBrandConfigureFor` content block. Currently configured for #{$_o-brand-current-variant}.';
     }
-    @if $config {
-        $brand: if($o-brand, $o-brand, $_o-brand-default);
-        // Get original config.
-        $original-config: _oBrandGetConfig($component, $brand);
-        // Override config.
-        $result: _oBrandUpdateConfig($component, $brand, $config);
-        @content;
-        // Remove override. Back to original config.
-        $result: _oBrandRestoreConfig($component, $brand, $original-config);
-    } @else {
-        @content;
+    @include oBrandConfigureFor($component, $variant: null) {
+        @if $config {
+            $brand: if($o-brand, $o-brand, $_o-brand-default);
+            // Get original config.
+            $original-config: _oBrandGetConfig($component, $brand);
+            // Override config.
+            $result: _oBrandUpdateConfig($component, $brand, $config);
+            @content;
+            // Remove override. Back to original config.
+            $result: _oBrandRestoreConfig($component, $brand, $original-config);
+        } @else {
+            @content;
+        }
     }
 }
 
@@ -119,24 +124,51 @@ $_o-brand-default-not-set-warning: false !default; // Has the default not set wa
 /// @access public
 /// @param {string} $component
 /// @param {string | list} $variables
-/// @param {string | list} $force-variant Get a variable for a specific variant, disregard any configured variant (`oBrandConfigureFor`).
+/// @param {string | list} $configure-for Get a variable for a specific variant, disregard any configured variant (`oBrandConfigureFor`).
 /// @return {string | number | color | null}
-@function oBrandGet($component, $variables, $force-variant: null) {
+@function oBrandGet($variables, $component: $_o-brand-current-component, $configure-for: $_o-brand-current-variant) {
     // For one variable return value.
-
+    @if $component == null {
+        @error 'Can not get variable "#{variables}" as the component is not configured. Use `oBrandConfigureFor` or pass a `$component` argument.';
+    }
     @if length($variables) == 1 {
-        @return _oBrandGetVariableValue($component, nth($variables, 1), $force-variant);
+        @return _oBrandGetVariableValue($component, nth($variables, 1), $configure-for);
     }
     // Concatenate multiple requested variables for use in one property.
     $values: ();
     @each $variable in $variables {
         @if $variable {
-            $values: join($values,  _oBrandGetVariableValue($component, $variable, $force-variant));
+            $values: join($values,  _oBrandGetVariableValue($component, $variable, $configure-for));
         }
     }
     @return $values;
 }
 
+
+// Update currently configured component and variant.
+// If a variant is already set for a component combine them.
+/// @access private
+/// @param {string} $component
+/// @param {string} $variant
+/// @param {map} $config
+@mixin _oBrandUpdateCurrent($component, $variant) {
+    @if ($variant and $_o-brand-current-component == $component and $_o-brand-current-variant) {
+        $variant: join($_o-brand-current-variant, $variant, 'comma');
+    }
+    $_o-brand-current-variant: if($variant, $variant, $_o-brand-current-variant) !global;
+    $_o-brand-current-component: $component !global;
+}
+
+// Reset currently configured component and variant.
+// Unlike `_oBrandUpdateCurrent` allows for a null variant.
+/// @access private
+/// @param {string} $component
+/// @param {string} $variant
+/// @param {map} $config
+@mixin _oBrandResetCurrent($component, $variant) {
+    $_o-brand-current-variant: $variant !global;
+    $_o-brand-current-component: $component !global;
+}
 
 /// Sets config for a given component and brand.
 ///
@@ -263,18 +295,17 @@ $_o-brand-default-not-set-warning: false !default; // Has the default not set wa
 /// @access private
 /// @param {string} $component
 /// @param {string} $variable
-/// @param {string | list} $force-variant Get a variable for a specific variant, disregard any configured variant (`oBrandConfigureFor`).
+/// @param {string | list} $variant Get a variable for a specific variant, disregard any configured variant (`oBrandConfigureFor`).
 /// @return {string | number | color | null}
-@function _oBrandGetVariableValue($component, $variable, $force-variant: null) {
+@function _oBrandGetVariableValue($component, $variable, $variant) {
     // Get all brand variables.
     $brand-config: _oBrandGetConfig($component, $o-brand);
     $variables: map-get($brand-config, 'variables');
     // Use variant variables if a variant is configured.
-    @if $force-variant and not (type-of($force-variant) == 'list' or type-of($force-variant) == 'string') {
-        @error 'Could not get get variable "#{$variable}" for component "#{$component}" and variant "#{$force-variant}", the variant should be of type string or list but was "#{type-of($force-variant)}".';
+    @if $variant and not (type-of($variant) == 'list' or type-of($variant) == 'string') {
+        @error 'Could not get get variable "#{$variable}" for component "#{$component}" and variant "#{$variant}", the variant should be of type string or list but was "#{type-of($variant)}".';
     }
-    $current-variant: if($force-variant, $force-variant, _oBrandGetCurrentVariant($component));
-    $variant-variables: map-get($variables, _oBrandNormaliseVariant($current-variant));
+    $variant-variables: map-get($variables, _oBrandNormaliseVariant($variant));
     @if type-of($variant-variables) == 'map' {
         $variables: $variant-variables;
     }
@@ -282,7 +313,7 @@ $_o-brand-default-not-set-warning: false !default; // Has the default not set wa
     @if type-of($variables) == 'map' {
         // Check the requested variable is defined.
         @if map-has-key($variables, $variable) == false and $o-brand-debug-mode == true {
-            @warn 'The "#{$variable}" variable is not defined for the ' + if(length($current-variant) > 0, 'variant "#{$current-variant}" of ', '') + 'the "#{$o-brand}" brand.';
+            @warn 'The "#{$variable}" variable is not defined for the ' + if(length($variant) > 0, 'variant "#{$variant}" of ', '') + 'the "#{$o-brand}" brand.';
             @return null;
         }
         // Get the defined value and validate it can be used as a CSS property.
@@ -296,58 +327,9 @@ $_o-brand-default-not-set-warning: false !default; // Has the default not set wa
     }
     // Warn but do not error if a variable is not defined for the current brand and variant.
     // A CSS property with SASS value `null`  will not be output.
-    @warn 'Variables are not set for ' + if(length($current-variant) > 0, 'the variant "#{$current-variant}" of ', '') + 'the "#{$o-brand}" brand.';
+    @warn 'Variables are not set for ' + if(length($variant) > 0, 'the variant "#{$variant}" of ', '') + 'the "#{$o-brand}" brand.';
     @return null;
 }
-
-
-/// Update the current variant to with a new variant.
-/// If a variant is already set they are compounded.
-///
-/// @access private
-/// @param {string} $component
-/// @param {string | list} $variant
-@mixin _oBrandAddToCurrentVariant($component, $variant) {
-    $current-variant: _oBrandGetCurrentVariant($component);
-    $current-depth: _oBrandGetCurrentDepth($component);
-    @if $current-depth == 0 {
-        $current-variant: $variant;
-    } @else {
-        $current-variant: join($current-variant, $variant, 'comma');
-    }
-    // Update current variant.
-    $current-variant: _oBrandSetCurrentVariant($component, $current-variant);
-    // Update current depth.
-    $current-depth: $current-depth + length($variant);
-    $current-depth: _oBrandSetCurrentDepth($component, $current-depth);
-}
-
-
-/// Update the current variant by removing a variant.
-///
-/// @access private
-/// @param {string} $component
-/// @param {string | list} $variant
-@mixin _oBrandRemoveFromCurrentVariant($component, $variant) {
-    $current-depth: _oBrandGetCurrentDepth($component);
-    $current-depth: $current-depth - length($variant);
-    // Set new current depth.
-    $current-depth: _oBrandSetCurrentDepth($component, $current-depth);
-    $current-variant: _oBrandGetCurrentVariant($component);
-    @if $current-depth == 0 {
-        $current-variant: _oBrandSetCurrentVariant($component, ());
-    }
-    $new-variants: ();
-    $num: 1;
-    @while $num <= $current-depth {
-        $new-variants: join($new-variants, (nth($current-variant, $num)), 'comma');
-        $num: $num + 1;
-    }
-    $current-variant: if(length($new-variants) == 0, (), $new-variants);
-    // Set new current variant.
-    $current-variant: _oBrandSetCurrentVariant($component, $current-variant);
-}
-
 
 /// Get all config for a given component and brand.
 ///
@@ -424,55 +406,6 @@ $_o-brand-default-not-set-warning: false !default; // Has the default not set wa
     @return $list;
     // sass-lint:enable variable-name-format
 }
-
-
-/// Get the current number of compound variants (depth) of a component.
-///
-/// @access private
-/// @param {string} $component
-/// @return {number}
-@function _oBrandGetCurrentDepth($component) {
-    $current-depth: map-get($_o-brand-depth, $component);
-    @return if(type-of($current-depth) == 'number', $current-depth, 0);
-}
-
-
-/// Update the current number of compound variants (depth) of a component.
-///
-/// @access private
-/// @param {string} $component
-/// @param {number} $current-depth
-/// @return {number}
-@function _oBrandSetCurrentDepth($component, $current-depth) {
-    $_o-brand-depth: map-merge($_o-brand-depth, ($component: $current-depth)) !global;
-    @return $current-depth;
-}
-
-
-/// Get the current variant of a component.
-///
-/// @access private
-/// @param {string} $component
-/// @return {list | string}
-@function _oBrandGetCurrentVariant($component) {
-    $current-variant: map-get($_o-brand-variant, $component);
-    // If one variant part return string consistently.
-    $current-variant: if(length($current-variant) == 1, nth($current-variant, 1), $current-variant);
-    @return $current-variant;
-}
-
-
-/// Update the current variant of a component.
-///
-/// @access private
-/// @param {string} $component
-/// @param {string | list} $current-variant
-/// @return {list}
-@function _oBrandSetCurrentVariant($component, $current-variant) {
-    $_o-brand-variant: map-merge($_o-brand-variant, ($component: $current-variant)) !global;
-    @return $current-variant;
-}
-
 
 /// Compares two strings to determine which comes first.
 /// Sort order defined in an alphanumeric list.

--- a/test-scss/_fixtures.scss
+++ b/test-scss/_fixtures.scss
@@ -1,5 +1,6 @@
 $o-brand: 'internal';
 
+// Define an example component
 @include oBrandDefine('o-example', 'master', (
 	'variables': (
 		example-background: pink
@@ -39,5 +40,34 @@ $o-brand: 'internal';
 @include oBrandDefine('o-example', 'whitelabel', (
 	'settings': (
 		'compact': true
+	)
+));
+
+// Define a second example component
+@include oBrandDefine('o-example-two', 'master', (
+	'variables': (
+		example-two-size: 2em,
+		'large': (
+			example-two-size: 3em,
+		),
+		'small': (
+			example-two-size: 1em,
+		)
+	),
+	'settings': (
+		'small': true,
+		'large': true
+	)
+));
+
+@include oBrandDefine('o-example-two', 'internal', (
+	'variables': (
+		example-two-size: 2em,
+		'small': (
+			example-two-size: 1em,
+		)
+	),
+	'settings': (
+		'small': true
 	)
 ));

--- a/test-scss/_mixins.test.scss
+++ b/test-scss/_mixins.test.scss
@@ -259,6 +259,24 @@
             @include assert-equal($property, 1em);
         }
     }
+
+    @include test('Gets a variable value which has been overridden') {
+        $custom-config: ('variables': (
+                'example-background': blue
+        ));
+        $property: oBrandGet($component: 'o-example', $variables: 'example-background', $override: $custom-config);
+        @include assert-equal($property, blue);
+    }
+
+    @include test('Gets a variant variable value which has been overridden') {
+        $custom-config: ('variables': (
+                'inverse': (
+                    'example-background': hotpink
+                )
+        ));
+        $property: oBrandGet($component: 'o-example', $variables: 'example-background', $configure-for: 'inverse', $override: $custom-config);
+        @include assert-equal($property, hotpink);
+    }
 }
 
 @include test-module('oBrandOverride') {

--- a/test-scss/_mixins.test.scss
+++ b/test-scss/_mixins.test.scss
@@ -59,6 +59,31 @@
             }
         }
 
+        @include assert('The variants for a nested component is supported by the test brand so should output') {
+            @include output {
+                @include oBrandConfigureFor($component: 'o-example', $variant: ('b2b' , 'inverse')) {
+                    @include oBrandConfigureFor($component: 'o-example-two', $variant: 'small') {
+                        content: 'variants supported by their component';
+                    }
+                }
+            }
+            @include expect {
+                content: 'variants supported by their component';
+            }
+        }
+
+        @include assert('The variants for a nested component are not supported by the test brand so should not output') {
+            @include output {
+                @include oBrandConfigureFor($component: 'o-example', $variant: ('b2b' , 'inverse')) {
+                    @include oBrandConfigureFor($component: 'o-example-two', $variant: 'large') {
+                        content: '"large" variant is not supported by the inner most component';
+                    }
+                }
+            }
+            @include expect {
+            }
+        }
+
         @include assert('The "b2b" variant is supported by the test brand so should output') {
             @include output {
                 @include oBrandConfigureFor($component: 'o-example', $variant: 'b2b') {
@@ -96,7 +121,7 @@
         @include assert('Null variants are supported.') {
             @include output {
                 @include oBrandConfigureFor($component: 'o-example', $variant: null) {
-                    background: oBrandGet($component: 'o-example', $variables: 'example-background');
+                    background: oBrandGet($variables: 'example-background');
                 }
             }
             @include expect {
@@ -108,17 +133,17 @@
             @include oBrandConfigureFor($component: 'o-example', $variant: 'inverse') {
                 @include oBrandConfigureFor($component: 'o-example', $variant: null) { // should have no effect
                     // variant: inverse
-                    $property: oBrandGet($component: 'o-example', $variables: 'example-background');
+                    $property: oBrandGet($variables: 'example-background');
                     @include assert-equal($property, grey);
                     // variant: inverse b2b
                     @include oBrandConfigureFor($component: 'o-example', $variant: 'b2b') {
                         @include oBrandConfigureFor($component: 'o-example', $variant: null) { // should have no effect
-                            $property: oBrandGet($component: 'o-example', $variables: 'example-background');
+                            $property: oBrandGet($variables: 'example-background');
                             @include assert-equal($property, darkred);
                         }
                     }
                     // variant: inverse
-                    $property: oBrandGet($component: 'o-example', $variables: 'example-background');
+                    $property: oBrandGet($variables: 'example-background');
                     @include assert-equal($property, grey);
                 }
             }
@@ -142,7 +167,7 @@
 
     @include test('Gets a variable value for a configured variant') {
         @include oBrandConfigureFor($component: 'o-example', $variant: 'inverse') {
-            $property: oBrandGet($component: 'o-example', $variables: 'example-background');
+            $property: oBrandGet($variables: 'example-background');
             @include assert-equal($property, grey);
         }
     }
@@ -150,12 +175,12 @@
     @include test('Gets a variable value for a configured compound variant, regardless of order') {
         // inverse b2b
         @include oBrandConfigureFor($component: 'o-example', $variant: ('b2b' , 'inverse')) {
-            $property: oBrandGet($component: 'o-example', $variables: 'example-background');
+            $property: oBrandGet($variables: 'example-background');
             @include assert-equal($property, darkred);
         }
         // b2b inverse
         @include oBrandConfigureFor($component: 'o-example', $variant: ('inverse', 'b2b')) {
-            $property: oBrandGet($component: 'o-example', $variables: 'example-background');
+            $property: oBrandGet($variables: 'example-background');
             @include assert-equal($property, darkred);
         }
     }
@@ -163,44 +188,75 @@
     @include test('Gets a variable value for a configured variant, regardless of list separator') {
         // space
         @include oBrandConfigureFor($component: 'o-example', $variant: ('b2b' 'inverse')) {
-            $property: oBrandGet($component: 'o-example', $variables: 'example-background');
+            $property: oBrandGet($variables: 'example-background');
             @include assert-equal($property, darkred);
         }
         // comma
         @include oBrandConfigureFor($component: 'o-example', $variant: ('b2b', 'inverse')) {
-            $property: oBrandGet($component: 'o-example', $variables: 'example-background');
+            $property: oBrandGet($variables: 'example-background');
             @include assert-equal($property, darkred);
         }
     }
 
-    @include test('Gets a variable value for a configured compound variant (nested)') {
+    @include test('Gets a variable value for a configured compound variant (nested variants)') {
         @include oBrandConfigureFor($component: 'o-example', $variant: 'inverse') {
             // variant: inverse
-            $property: oBrandGet($component: 'o-example', $variables: 'example-background');
+            $property: oBrandGet($variables: 'example-background');
             @include assert-equal($property, grey);
             // variant: inverse b2b
             @include oBrandConfigureFor($component: 'o-example', $variant: 'b2b') {
-                $property: oBrandGet($component: 'o-example', $variables: 'example-background');
+                $property: oBrandGet($variables: 'example-background');
                 @include assert-equal($property, darkred);
             }
             // variant: inverse
-            $property: oBrandGet($component: 'o-example', $variables: 'example-background');
+            $property: oBrandGet($variables: 'example-background');
+            @include assert-equal($property, grey);
+        }
+    }
+
+    @include test('Gets a variable value for a configured compound variant (nested components)') {
+        @include oBrandConfigureFor($component: 'o-example', $variant: 'inverse') {
+            // component: o-example, variant: inverse
+            $property: oBrandGet($variables: 'example-background');
+            @include assert-equal($property, grey);
+            // component: o-example, variant: inverse b2b
+            @include oBrandConfigureFor($component: 'o-example', $variant: 'b2b') {
+                // component: o-example-two, variant: small
+                @include oBrandConfigureFor($component: 'o-example-two', $variant: 'small') {
+                    $property: oBrandGet($variables: 'example-two-size');
+                    @include assert-equal($property, 1em);
+                    // example-background not fonfigured for the "example-two" components
+                    $property: oBrandGet($variables: 'example-background');
+                    @include assert-equal($property, null);
+                }
+            }
+            // component: o-example, variant: inverse
+            $property: oBrandGet($variables: 'example-background');
             @include assert-equal($property, grey);
         }
     }
 
     @include test('Gets a variable value for a "forced" variant') {
-        $property: oBrandGet($component: 'o-example', $variables: 'example-background', $force-variant: 'inverse');
+        $property: oBrandGet($component: 'o-example', $variables: 'example-background', $configure-for: 'inverse');
         @include assert-equal($property, grey);
 
-        $property: oBrandGet($component: 'o-example', $variables: 'example-background', $force-variant: ('inverse', 'b2b'));
+        $property: oBrandGet($component: 'o-example', $variables: 'example-background', $configure-for: ('inverse', 'b2b'));
         @include assert-equal($property, darkred);
     }
 
-    @include test('Gets a variable value for a "forced" variant, ignoring configured variants') {
+    @include test('Gets a variable value for an explicit variant, ignoring currently configured variants') {
         @include oBrandConfigureFor($component: 'o-example', $variant: 'b2b') {
-            $property: oBrandGet($component: 'o-example', $variables: 'example-background', $force-variant: 'inverse');
+            $property: oBrandGet($variables: 'example-background', $configure-for: 'inverse');
             @include assert-equal($property, grey);
+        }
+    }
+
+    @include test('Gets a variable value for an explicit variant, ignoring currently configured components') {
+        @include oBrandConfigureFor($component: 'o-example', $variant: 'b2b') {
+            $property: oBrandGet($variables: 'example-background', $component: 'o-example-two');
+            @include assert-equal($property, null);
+            $property: oBrandGet($variables: 'example-two-size', $component: 'o-example-two', $configure-for: 'small');
+            @include assert-equal($property, 1em);
         }
     }
 }
@@ -210,7 +266,7 @@
         @include oBrandOverride($component: 'o-example', $config: ('variables': (
                 'example-background': blue
             ))) {
-            $property: oBrandGet($component: 'o-example', $variables: 'example-background');
+            $property: oBrandGet($variables: 'example-background');
             @include assert-equal($property, blue);
         }
     }

--- a/test-scss/_mixins.test.scss
+++ b/test-scss/_mixins.test.scss
@@ -264,7 +264,7 @@
         $custom-config: ('variables': (
                 'example-background': blue
         ));
-        $property: oBrandGet($component: 'o-example', $variables: 'example-background', $override: $custom-config);
+        $property: oBrandGet($component: 'o-example', $variables: 'example-background', $override-config: $custom-config);
         @include assert-equal($property, blue);
     }
 
@@ -274,7 +274,7 @@
                     'example-background': hotpink
                 )
         ));
-        $property: oBrandGet($component: 'o-example', $variables: 'example-background', $configure-for: 'inverse', $override: $custom-config);
+        $property: oBrandGet($component: 'o-example', $variables: 'example-background', $configure-for: 'inverse', $override-config: $custom-config);
         @include assert-equal($property, hotpink);
     }
 }


### PR DESCRIPTION
**oBrandGet**
- `$component` argument can be omitted when used with `oBrandConfigureFor` or `oBrandOverride`
- `$force-variant` argument renamed `$configure-for`.
- `$override` argument added.

**oBrandConfigureFor**
- Interface unchanged. Uses of `oBrandGet` within a configured content block no longer has to specify a component.

**oBrandOverride**
- Interface unchanged. Uses of `oBrandGet` within an overridden content block no longer has to specify a component.

**E.g.**

Before:
```
@include oBrandConfigureFor($component: 'o-example', $variant: 'inverse') {
    background: oBrandGet($component: 'o-example', $variables: 'mybackground');
    color: oBrandGet($component: 'o-example', $variables: 'mycolor');
}
```
After:
```
@include oBrandConfigureFor($component: 'o-example', $variant: 'inverse') {
    background: oBrandGet($variables: 'mybackground');
    color: oBrandGet($variables: 'mycolor');
}
```