### PR TITLE
No not return a variable value for a variant with no variables defined.

### DIFF
--- a/scss/mixins.scss
+++ b/scss/mixins.scss
@@ -335,6 +335,7 @@ $_o-brand-default-not-set-warning: false !default; // Has the default not set wa
     }
     @if $variant and $variant != '' {
         $variant-variables: map-get($variables, _oBrandNormaliseVariant($variant));
+        $variables: null;
         @if type-of($variant-variables) == 'map' {
             $variables: $variant-variables;
         }
@@ -357,7 +358,9 @@ $_o-brand-default-not-set-warning: false !default; // Has the default not set wa
     }
     // Warn but do not error if a variable is not defined for the current brand and variant.
     // A CSS property with SASS value `null`  will not be output.
-    @warn 'Variables are not set for ' + if(length($variant) > 0, 'the variant "#{$variant}" of ', '') + 'the "#{$o-brand}" brand.';
+    @if $o-brand-debug-mode {
+        @warn 'Variables are not set for ' + if(length($variant) > 0, 'the variant "#{$variant}" of ', '') + 'the "#{$o-brand}" brand.';
+    }
     @return null;
 }
 
@@ -386,7 +389,6 @@ $_o-brand-default-not-set-warning: false !default; // Has the default not set wa
     }
     @return $brand-config;
 }
-
 
 /// Ensure variants are expressed consistently,
 /// so they may be compared and matched.

--- a/test/scss/_mixins.test.scss
+++ b/test/scss/_mixins.test.scss
@@ -183,6 +183,13 @@
         }
     }
 
+    @include test('Does not get a variable value for a variant with no variables defined') {
+        @include oBrandConfigureFor($component: 'o-example', $variant: 'compact') {
+            $property: oBrandGet($variables: 'example-background');
+            @include assert-equal($property, null);
+        }
+    }
+
     @include test('Gets a variable value for a configured compound variant, regardless of order') {
         // inverse b2b
         @include oBrandConfigureFor($component: 'o-example', $variant: ('b2b' , 'inverse')) {


### PR DESCRIPTION
Currently if a variant is not configured at all `o-brand` falls back to default variables.