### PR TITLE
Update interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Brands include:
 
 ### Variant
 
-A variant is an addition or modification to a component withi a given brand. A variant may also alter the appearance and/or functionality of a component. Variants must be optional and build upon a fully functional component.
+A variant is an addition or modification to a component within a given brand. A variant may also alter the appearance and/or functionality of a component. Variants must be optional and build upon a fully functional component.
 
 E.g. A button component may have an "inverse" variant, a "big" variant, etc. A header component may have a "subnav" variant, a "sticky" variant, etc.
 
@@ -47,6 +47,7 @@ The following mixins and functions help brand a component.
 
 - [oBrandDefine](#obranddefine) - Define brand configuration (variables & supported variants).
 - [oBrandGet](#obrandget) - Retrieve brand variables.
+- [oBrandSupportsVariant](#obrandsupportsvariant) - Check if the brand supports a variant.
 
 ### oBrandDefine
 
@@ -54,12 +55,12 @@ A component defines configuration for each of its supported brands. The default 
 
 Brand configuration comprises of variables and supported variants. As explained below.
 - [`variables`](#brand-variables)
-- [`supported-variants`](#supported-variants)
+- [`supports-variants`](#supports-variants)
 
 ```scss
 @include oBrandDefine($component: 'o-example', $brand: 'master', (
     'variables': $variables,
-    'supported-variants': $supported-variants
+    'supports-variants': $supports-variants
 ));
 ```
 
@@ -104,7 +105,7 @@ These ensures support for a variant which sets no variables can be determined.
 
 #### A Complete `oBrandDefine` Example
 
-The below example defines a `master` brand for the component `o-example`. We define four variables including `example-background`, but we provide is a different `example-background` value for the `inverse` and `b2b` variants. Using the `supports-variants` map we explicitly state the `master` brand supports both of these variants.
+The below example defines a `master` brand for the component `o-example`. We define four variables including `example-background`, but we provide a different `example-background` value for the `inverse` and `b2b` variants. Using the `supports-variants` map we explicitly state the `master` brand supports both of these variants.
 
 ```scss
 @include oBrandDefine('o-example', 'master', (
@@ -166,6 +167,19 @@ $custom-variant: (
 ```
 
 - `oBrandGet` returns `null` if a variable is undefined. Sass removes css properties which are set to `null`. This is a useful feature to conditionally output css properties for different variants.
+
+## oBrandSupportsVariant
+
+To check if a brand supports a variant call `oBrandSupportsVariant`.
+
+E.g. only output the `inverse` variant if the brand supports it:
+```scss
+@if oBrandSupportsVariant($component: 'o-example', $variant: 'inverse') {
+	.o-example--inverse {
+		background: oBrandGet($component: 'o-example', $variables: 'example-background', $from: 'inverse'); // background: slate;
+	}
+}
+```
 
 ### Debug Mode
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Tools to tailor Origami components for distinct usecases.
 
 ### Brand
 
-A brand is a collection of configuration to tailor a component for distinct use-cases. A branded Origami component is able to output differing styles for a requested brand. It is also able to include extra styles specific to a brand.
+A brand represents an enviroment which requires components to offer a distinct appearence or unique functionality.
 
 Brands include:
 
@@ -27,15 +27,15 @@ Brands include:
 
 ### Variant
 
-A variant is an addition or modification of a component. A variant may alter the appearance and/or functionality of a component. Variants must be optional and build upon a fully functional component.
+A variant is an addition or modification to a component withi a given brand. A variant may also alter the appearance and/or functionality of a component. Variants must be optional and build upon a fully functional component.
 
 E.g. A button component may have an "inverse" variant, a "big" variant, etc. A header component may have a "subnav" variant, a "sticky" variant, etc.
 
 ## Motivation
 
-As of March 2018 Origami components provide master brand specific styles inconsistently. Some components aim to provide a generic foundation for visually distinct clients to build upon, e.g. `o-table`, but include CSS classes which unpredictably introduce heavy master brand specific styles. This means some clients need to manually override master brand styles with extra CSS. It also means a non-masterbrand client cannot be confident that new master brand styles will not creep in over time.
+As of March 2018 Origami components provide master brand specific styles inconsistently. Some components aim to provide a generic foundation for visually distinct clients to build upon, e.g. `o-table`, but include CSS classes which unpredictably introduce heavy "master" brand specific styles. This means some clients need to manually override "master" brand styles with extra CSS. It also means a non-masterbrand client cannot be confident that new "master" brand styles will not creep in over time.
 
-Branded components aim to provide styles for "master" and "internal" products which are immediately usable with little or no modification. For products where those do not apply a "whitelabel" brand provides a reliable foundation with little visual styling to build upon.
+Branded components aim to provide styles for "master" and "internal" branded products which are immediately usable with little or no modification. For products where those do not apply a "whitelabel" brand provides a reliable foundation with little visual styling to build upon.
 
 ## Sass
 
@@ -45,23 +45,21 @@ Mixins within `o-brand` help configure components to support brands. There is no
 
 The following mixins and functions help brand a component.
 
-- [oBrandDefine](#obranddefine) - Define brand configuration (variables & settings).
+- [oBrandDefine](#obranddefine) - Define brand configuration (variables & supported variants).
 - [oBrandGet](#obrandget) - Retrieve brand variables.
-- [oBrandConfigureFor](#obrandconfigurefor) - Choose a variant and automatically configure `oBrandGet`.
-- [oBrandOverride](#obrandoverride) - Customise a defined brand to automatically override `oBrandGet`.
 
 ### oBrandDefine
 
 A component defines configuration for each of its supported brands. The default brand `master` must be defined. To do that use the mixin `oBrandDefine`.
 
-Brand configuration comprises of variables and settings. As explained below.
+Brand configuration comprises of variables and supported variants. As explained below.
 - [`variables`](#brand-variables)
-- [`settings`](#brand-settings)
+- [`supported-variants`](#supported-variants)
 
 ```scss
 @include oBrandDefine($component: 'o-example', $brand: 'master', (
     'variables': $variables,
-    'settings': $settings
+    'supported-variants': $supported-variants
 ));
 ```
 
@@ -86,61 +84,43 @@ $variables: (
 );
 ```
 
-Two or more variants may be used together to create a new variant. E.g. a "b2b" variant might provide a different background color when used along with the "inverse" variant.
-
-```scss
-$variables: (
-	example-background: 'paper',
-	'inverse': (
-		example-background: 'slate'
-	)
-	'b2b': (
-		example-background: 'lightblue'
-	)
-	('b2b', 'inverse'): (
-		example-background: 'darkblue'
-	)
-);
-```
-
 - Variable names must be a string and should be alphanumeric, including dashes e.g. `example-background`.
 - Variable names should not match css properties exactly e.g. `example-background` over `background`.
-- A variant must be an alphanumeric string or list of alphanumeric strings e.g. `inverse`, `('b2b', 'inverse')`.
+- A variant must be an alphanumeric string e.g. `inverse`, `b2b-inverse`.
 
-#### Brand Settings
+#### Supported Variant
 
-Variants are unsupported by default. To enable a variant for a brand, add the variant name to the settings map if the brand supports it. Brand settings provide boolean flags to turn variants on.
+To indicate a brand should support a variant, add the variant name to the `supports-variants` map.
 
-E.g. To configure support for inverse and b2b variants:
+E.g. To configure support for "inverse" and "b2b" variants:
 ```scss
-$settings: (
+$supports-variants: (
 	'inverse': true,
 	'b2b': true
 );
 ```
 
-- Some variants may not need variables, but may still exist in a component. This means the variant still needs to be set within the brand settings. E.g. a "sticky" variant of a header may need no configuration, other than a setting to turn support on/off.
+These ensures support for a variant which sets no variables can be determined.
 
 #### A Complete `oBrandDefine` Example
 
-The below example defines a brand `master` for the component `o-example`. We define a variable `example-background`. There is a different `example-background` value for the `inverse` and `b2b inverse` variant. Using the settings map we state the `master` brand supports these two variants.
+The below example defines a `master` brand for the component `o-example`. We define four variables including `example-background`, but we provide is a different `example-background` value for the `inverse` and `b2b` variants. Using the `supports-variants` map we explicitly state the `master` brand supports both of these variants.
 
 ```scss
 @include oBrandDefine('o-example', 'master', (
     'variables': (
 		example-background: 'paper',
+		example-border-width: 1px,
+		example-border-type: solid,
+		example-border-type: grey,
 		'inverse': (
 			example-background: 'slate'
 		)
 		'b2b': (
 			example-background: 'lightblue'
 		)
-		('b2b', 'inverse'): (
-			example-background: 'darkblue'
-		)
     ),
-    'settings': (
-        'b2b': true,
+    'supports-variants': (
         'inverse': true
     )
 ));
@@ -157,112 +137,41 @@ E.g. building on the `oBrandDefine` example:
 }
 ```
 
-To request multiple variables at once, assuming variables `example-border-size: 1px`, `example-border-type: solid`, `example-border-color: grey` are defined using `oBrandDefine`:
+It is possible to request multiple variables:
 ```scss
 .o-example {
-	border: oBrandGet($component: 'o-example', $variables: ('example-border-size', 'example-border-type', 'example-border-color')); // border: 1px solid grey;
+	border: oBrandGet($component: 'o-example', $variables: ('example-border-width', 'example-border-type', 'example-border-color')); // border: 1px solid grey;
 }
 ```
 
-Retrieve a variable for a variant using `oBrandGet` and `$configure-for`.
+To retrieve a variable for a variant use the `$from` argument of `oBrandGet`.
 ```scss
 .o-example--inverse {
-	background: oBrandGet($component: 'o-example', $variables: 'example-background', $configure-for: 'inverse'); // background: slate;
+	background: oBrandGet($component: 'o-example', $variables: 'example-background', $from: 'inverse'); // background: slate;
 }
 ```
 
-Override variables using `oBrandGet` and `$override-config`. The override paramater accepts configuration to override brand configuration set with `oBrandDefine`, it expects the same configuration format.
-
-Assuming variables `example-background: 'paper'`, `example-border-size: 1px`, `example-border-type: solid`, `example-border-color: grey` are defined using `oBrandDefine`:
+The `$from` argument `oBrandGet` also accepts a custom variant:
 
 ```scss
-$custom-config: (
-	'variables': (
-		'example-background': 'hotpink',
-		'example-border-size', '2px'
-	)
+$custom-variant: (
+	'example-background': 'hotpink',
+	'example-border-width', '2px'
 );
 
-.o-example {
-	background: oBrandGet($component: 'o-example', $variables: 'example-background', $override-config: $custom-config); // background: hotpink;
-	border: oBrandGet($component: 'o-example', $variables: ('example-border-size', 'example-border-type', 'example-border-color'), $override-config: $custom-config); // border: 2px solid grey;
+.o-example--custom {
+	background: oBrandGet($component: 'o-example', $variables: 'example-background', $from: $custom-variant); // background: hotpink;
+	border-width: oBrandGet($component: 'o-example', $variables: 'example-border-width', $from: $custom-variant); // border-width: 2px;
 }
 ```
 
 - `oBrandGet` returns `null` if a variable is undefined. Sass removes css properties which are set to `null`. This is a useful feature to conditionally output css properties for different variants.
-- Whilst it is possible to get a brand variable for an explicit component and variant using `oBrandGet`, instead use [`oBrandConfigureFor`](#obrandconfigurefor) where possible.
-- Whilst it is possible to override any defined variable using `oBrandGet`, instead use [`oBrandOverride`](#obrandoverride) where possible.
-
-### oBrandConfigureFor
-
-`oBrandConfigureFor` configures all `oBrandGet` calls within its content block for a given component and variant, which removes the need to repeatedly pass the component and variant to `oBrandGet`. In addition it will only output the sass content block if the component brand supports the given variant.
-
-Building on the `oBrandDefine` example the following outputs multiple `o-example` variants with different backgrounds. The variants are only output if the brand supports them:
-
-```scss
-@include oBrandConfigureFor($component: 'o-example', $variant: 'inverse') {
-	.o-example--inverse {
-		background: oBrandGet($variables: 'example-background'); // background: paper;
-	}
-}
-
-@include oBrandConfigureFor($component: 'o-example', $variant: 'b2b') {
-	.o-example--b2b {
-		background: oBrandGet($variables: 'example-background'); // background: lightblue;
-	}
-}
-
-@include oBrandConfigureFor($component: 'o-example', $variant: ('b2b', 'inverse')) {
-	.o-example--b2b .o-example--inverse {
-		background: oBrandGet($variables: 'example-background'); // background: darkblue;
-	}
-}
-```
-
-`oBrandConfigureFor` may also be nested:
-
-```scss
-@mixin oExampleTheme() {
-	background: oBrandGet($variables: 'example-background');
-}
-
-// "b2b" variant
-@include oBrandConfigureFor($component: 'o-example', $variant: 'b2b') {
-	.o-example--b2b {
-		@include oExampleTheme(); // background: lightblue;
-		// "b2b inverse" variant
-		@include oBrandConfigureFor($component: 'o-example', $variant: 'inverse') {
-			&.o-example--inverse {
-				@include oExampleTheme(); // background: darkblue;
-			}
-		}
-	}
-}
-```
-
-### oBrandOverride
-
-To customise a brand use the `oBrandOverride` mixin. It accepts configuration, including variables and settings, in the same format as `oBrandDefine`.  Sass within the `oBrandOverride` content block uses `oBrandDefine` configuration merged with  `oBrandOverride` configuration.
-
-```scss
-$custom-config: ('variables', {
-	'example-background': hotpink
-});
-
-.o-example--custom-variant {
-	@include oBrandOverride('o-example', $custom-config) {
-		background: oBrandGet($variables: 'example-background'); // background: hotpink
-	};
-}
-```
 
 ### Debug Mode
 
 Some warnings are not output by default but may be useful in certain circumstances.
 
 To output all warnings set debug mode to true: `$o-brand-debug-mode: true;`.
-
-For example, no warning is output if a component uses `oBrandConfigureFor` and `oBrandGet` to get a variant variable which is not configured. This is a valid method to conditionally output CSS properties if a corresponding variant variable is configured. In other cases it might be useful to know where variant configuration has been missed using debug mode.
 
 ---
 

--- a/scss/mixins.scss
+++ b/scss/mixins.scss
@@ -245,7 +245,7 @@ $_o-brand-default-not-set-warning: false !default; // Has the default not set wa
     $variables: map-get($config, 'variables');
     $supports-variants: if(map-get($config, 'settings'), map-get($config, 'settings'), map-get($config, 'supports-variants'));
     @if map-get($config, 'settings') and $o-brand-debug-mode {
-        @warn 'Defining brands with "settings" is deprecated. Use "supported-variants" instead for component "#{$component}" and brand "#{$brand}".';
+        @warn 'Defining brands with "settings" is deprecated. Use "supports-variants" instead for component "#{$component}" and brand "#{$brand}".';
     }
     // Ensure a variant list is alphabetical.
     $sorted-variables: ();

--- a/scss/mixins.scss
+++ b/scss/mixins.scss
@@ -26,7 +26,6 @@ $_o-brand-default-not-set-warning: false !default; // Has the default not set wa
     }
 }
 
-
 /// Configures a content block for a brand variant.
 /// A single variant (string) or compound variant (list) is accepted.
 /// This mixin may also be nested to target compound variants.
@@ -47,10 +46,14 @@ $_o-brand-default-not-set-warning: false !default; // Has the default not set wa
 ///        // Will use configuration for the compound variant 'inverse,b2b' when fetching variable values.
 ///     }
 ///
+/// @deprecated
 /// @access public
 /// @param {string} $component
 /// @param {string | list} $variant
 @mixin oBrandConfigureFor($component, $variant: null) {
+    @if $o-brand-debug-mode {
+        @warn "oBrandConfigureFor is deprecated and will be removed in the next major of `o-brand`";
+    }
     // The default brand must be configured before o-brand can be used.
     @if not _oBrandIsDefined($component) {
         @error 'The default brand "#{$_o-brand-default}" must be defined for "#{$component}" before using o-brand.';
@@ -90,10 +93,14 @@ $_o-brand-default-not-set-warning: false !default; // Has the default not set wa
 ///     	};
 ///     }
 ///
+/// @deprecated
 /// @access public
 /// @param {string} $component
 /// @param {map} $config
 @mixin oBrandOverride($component, $config) {
+    @if $o-brand-debug-mode {
+        @warn "oBrandOverride is deprecated and will be removed in the next major of `o-brand`";
+    }
     $variants-configured: if($_o-brand-current-variant, length($_o-brand-current-variant), 0);
     @if($variants-configured > 0) {
         @error '`oBrandOverride` must wrap any `oBrandConfigureFor` call. Brand config cannot be overriden within a `oBrandConfigureFor` content block. Currently configured for #{$_o-brand-current-variant}.';
@@ -123,13 +130,35 @@ $_o-brand-default-not-set-warning: false !default; // Has the default not set wa
 /// @access public
 /// @param {string} $component
 /// @param {string | list} $variables
-/// @param {string | list} $configure-for Get a variable for a specific variant, disregards any configured variant of `oBrandConfigureFor`.
-/// @param {map} $override-config Configuration to override defined brand configuration. Expects the same as the `oBrandDefine` `$config` argument.
+/// @param {string | list} $configure-for Deprecated use $from: Get a variable for a specific variant, disregards any configured variant of `oBrandConfigureFor`.
+/// @param {map} $override-config Deprecated use $from: Configuration to override defined brand configuration. Expects the same as the `oBrandDefine` `$config` argument.
+/// @param {map|list|string} $from Get variable values from a defined brand variant or from a map of variables. Use instead of `$override-config` and `$configure-for`.
 /// @return {string | number | color | null}
-@function oBrandGet($variables, $component: $_o-brand-current-component, $configure-for: $_o-brand-current-variant, $override-config: $_o-brand-current-override) {
+@function oBrandGet($variables, $component: $_o-brand-current-component, $configure-for: $_o-brand-current-variant, $override-config: $_o-brand-current-override, $from: null) {
+    @if ($override-config != $_o-brand-current-override) and $o-brand-debug-mode {
+        @warn 'The `oBrandGet` argument `$override-config` is deprecated.';
+    }
+    @if ($configure-for != $_o-brand-current-variant) and $o-brand-debug-mode {
+        @warn 'The `oBrandGet` argument `$configure-for` is deprecated.';
+    }
+    @if type-of($from) == 'map' {
+        $values: null;
+        @each $variable in $variables {
+            $value: map-get($from, $variable);
+            @if $values {
+                $values: join($values, $value);
+            } @else {
+                $values: $value;
+            }
+        }
+        @return $values;
+    }
    // Ignore a null `$configure-for` variant.
     @if $configure-for == null {
         $configure-for: $_o-brand-current-variant;
+    }
+    @if type-of($from) == 'string' {
+        $configure-for: $from;
     }
     // For one variable return value.
     @if $component == null {
@@ -214,11 +243,14 @@ $_o-brand-default-not-set-warning: false !default; // Has the default not set wa
     // Validate config
     $valid: _oBrandValidateConfig($component, $brand, $config);
     $variables: map-get($config, 'variables');
-    $settings: map-get($config, 'settings');
-    // Ensure compound variant lists are alphabetical.
+    $supports-variants: if(map-get($config, 'settings'), map-get($config, 'settings'), map-get($config, 'supports-variants'));
+    // Ensure a variant list is alphabetical.
     $sorted-variables: ();
     @each $key, $value in $variables {
         @if type-of($value) == 'map' {
+            @if type-of($key) == 'list' and $o-brand-debug-mode {
+                @warn 'Defining variants as lists is deprecated. Use strings instead. Variant "#{$key}" of brand "#{$brand}" for component "#{$component}".';
+            }
             $key: _oBrandNormaliseVariant($key);
         }
         $sorted-variables: map-merge($sorted-variables, ($key: $value));
@@ -226,7 +258,7 @@ $_o-brand-default-not-set-warning: false !default; // Has the default not set wa
     // Update config.
     $_o-brands: _oBrandRecursiveMapMerge($_o-brands, ($component: ($brand: (
         'variables': $sorted-variables,
-        'settings': $settings
+        'supports-variants': $supports-variants
     )))) !global;
     @return $_o-brands;
 }
@@ -244,18 +276,17 @@ $_o-brand-default-not-set-warning: false !default; // Has the default not set wa
     @if type-of($config) != 'map' {
         @error '#{$errorMessage}. Its configuration must be a map.';
     }
-    // Validate brand variables and settings.
+    // Validate brand variables and supported variants.
     $variables: map-get($config, 'variables');
-    $settings: map-get($config, 'settings');
+    $supports-variants: if(map-get($config, 'settings'), map-get($config, 'settings'), map-get($config, 'supports-variants'));
     @if $variables and (type-of($variables) != 'map' and type-of($variables) != 'list' ) {
         @error '#{$errorMessage}. Config key "variables" should be a map but is of type #{type-of($variables)}.';
     }
-    @if $settings and (type-of($settings) != 'map' and type-of($settings) != 'list' ) {
-        @error '#{$errorMessage}. Config key "settings" should be a map but is of type #{type-of($settings)}.';
+    @if $supports-variants and (type-of($supports-variants) != 'map' and type-of($supports-variants) != 'list' ) {
+        @error '#{$errorMessage}. Config key "$supports-variants" should be a map but is of type #{type-of($supports-variants)}.';
     }
     @return true;
 }
-
 
 /// Check the brand is configured.
 /// By default checks the default brand is configured.
@@ -271,8 +302,17 @@ $_o-brand-default-not-set-warning: false !default; // Has the default not set wa
     @return type-of(map-get($component-brands, $brand)) == 'map';
 }
 
+/// Check if the brand supports a variant.
+///
+/// @access public
+/// @param {string} $component
+/// @param {string} $variant
+/// @return {boolean}
+@function oBrandSupportsVariant($component, $variant) {
+    @return _oBrandSupports($component, $variant);
+}
 
-/// Check the brand's configured settings to see if it supports a variant.
+/// Check the brand's configured supported variants to see if it supports a variant.
 /// Using this function and a conditional may make sense if there is no variant specific configuration.
 /// However `oBrandConfigureFor` should be used instead where possible.
 /// Doing so will support variant specific configuration in the future without code changes.
@@ -294,23 +334,23 @@ $_o-brand-default-not-set-warning: false !default; // Has the default not set wa
     @if $override {
         $result: _oBrandUpdateConfig($component, $brand, $override);
     }
-    // Get all brand settings, which are used to indicate variant support.
+    // Get supported variants.
     $brand-config: _oBrandGetConfig($component, $o-brand);
-    $brand-settings: map-get($brand-config, 'settings');
+    $supports-variants: if(map-get($brand-config, 'settings'), map-get($brand-config, 'settings'), map-get($brand-config, 'supports-variants'));
     // Restore original config.
     @if $override {
         $result: _oBrandRestoreConfig($component, $brand, $original-config);
     }
-    // No settings are enabled so no variants are supported.
-    @if type-of($brand-settings) != 'map' {
+    // No variants are supported.
+    @if type-of($supports-variants) != 'map' {
         @return false;
     }
-    // Check for a setting name which matches the variant.
-    // Each part of a compound variant should be specified with its own setting.
-    // E.g. Variant ('stripe', 'compact') is enabled with both 'stripe' and 'compact' settings set to true.
+    // @deprecated When variants are combined as a list, assume support if each individual part is supported.
+    // E.g. a 'compact' variant may be combined with a 'stripe' variant as ('stripe', 'compact').
+    // For a combined variant ('stripe', 'compact') to be supported 'compact' and 'stripe' must be supported individually.
     @each $variant-part in $variant {
-        $setting-defined: type-of($brand-settings) == 'map' and map-has-key($brand-settings, $variant-part);
-        @if $setting-defined == false or map-get($brand-settings, $variant-part) == false {
+        $variant-part-defined: type-of($supports-variants) == 'map' and map-has-key($supports-variants, $variant-part);
+        @if $variant-part-defined == false or map-get($supports-variants, $variant-part) == false {
             @return false;
         }
     }

--- a/scss/mixins.scss
+++ b/scss/mixins.scss
@@ -244,6 +244,9 @@ $_o-brand-default-not-set-warning: false !default; // Has the default not set wa
     $valid: _oBrandValidateConfig($component, $brand, $config);
     $variables: map-get($config, 'variables');
     $supports-variants: if(map-get($config, 'settings'), map-get($config, 'settings'), map-get($config, 'supports-variants'));
+    @if map-get($config, 'settings') and $o-brand-debug-mode {
+        @warn 'Defining brands with "settings" is deprecated. Use "supported-variants" instead for component "#{$component}" and brand "#{$brand}".';
+    }
     // Ensure a variant list is alphabetical.
     $sorted-variables: ();
     @each $key, $value in $variables {
@@ -381,11 +384,6 @@ $_o-brand-default-not-set-warning: false !default; // Has the default not set wa
     }
     // Variables for the current brand and variant found.
     @if type-of($variables) == 'map' {
-        // Check the requested variable is defined.
-        @if map-has-key($variables, $variable) == false and $o-brand-debug-mode == true {
-            @warn 'The "#{$variable}" variable is not defined for the ' + if(length($variant) > 0, 'variant "#{$variant}" of ', '') + 'the "#{$o-brand}" brand.';
-            @return null;
-        }
         // Get the defined value and validate it can be used as a CSS property.
         // Boolean variant and feature toggles are configured seperately.
         $value: map-get($variables, $variable);

--- a/test/scss/_mixins.test.scss
+++ b/test/scss/_mixins.test.scss
@@ -183,6 +183,13 @@
         }
     }
 
+    @include test('If no variant variables are configured the default variable is fetched') {
+        @include oBrandConfigureFor($component: 'o-example', $variant: 'compact') {
+            $property: oBrandGet($variables: 'example-background');
+            @include assert-equal($property, white);
+        }
+    }
+
     @include test('Gets a variable value for a configured compound variant, regardless of order') {
         // inverse b2b
         @include oBrandConfigureFor($component: 'o-example', $variant: ('b2b' , 'inverse')) {

--- a/test/scss/_mixins.test.scss
+++ b/test/scss/_mixins.test.scss
@@ -4,7 +4,7 @@
             'variables': (
                 example: blue
             ),
-            'settings': (
+            'supports-variants': (
                 'test': true,
                 'example': true
             )
@@ -12,7 +12,7 @@
         $component1-brand2: (
             'variables': (
             ),
-            'settings': (
+            'supports-variants': (
                 'example': true
             )
         );
@@ -20,7 +20,7 @@
             'variables': (
                 other: red
             ),
-            'settings': (
+            'supports-variants': (
                 'thing': true
             )
         );
@@ -28,7 +28,7 @@
             'variables': (
                 other: white
             ),
-            'settings': (
+            'supports-variants': (
             )
         );
         @include oBrandDefine('o-component1', 'brand1', $component1-brand1);
@@ -181,6 +181,16 @@
             $property: oBrandGet($variables: 'example-background');
             @include assert-equal($property, grey);
         }
+    }
+
+    @include test('Gets a variable value from a variant') {
+        $property: oBrandGet($component: 'o-example', $variables: 'example-background', $from: 'inverse');
+        @include assert-equal($property, grey);
+    }
+
+    @include test('Gets a variable value from a custom variant') {
+        $property: oBrandGet($component: 'o-example', $variables: 'example-background', $from: ('example-background': hotpink));
+        @include assert-equal($property, hotpink);
     }
 
     @include test('If no variant variables are configured the default variable is fetched') {


### PR DESCRIPTION
Deprecates:
- `oBrandConfigureFor` 
- `oBrandOverride` 
- `$configure-for` and `$override-config` arguments of `oBrandGet`
- Deprecates the use of `settings: ()` to configure brands, replaces with `supports-variants: ()`

Adds:
- `$from` argument to `oBrandGet` (replaces `$configure-for` and `$override-config`)

Rollout plan:
1. Release `o-brand` minor with updated `oBrandGet` interface and other mixin deprecations.
2. Update components to remove uses of deprecations.
3. Release `v2` major of `o-brand` which removes deprecations.
4. Update all component dependancies to allow either `o-brand@v1` or `o-brand@v2` major.
5. Confirm all branded components support  `o-brand@v2`.
6. Update all component dependancies to require `o-brand@v2`.