### PR TITLE
Improve error message when config keys are missing

### DIFF
--- a/scss/mixins.scss
+++ b/scss/mixins.scss
@@ -149,7 +149,13 @@ $_o-brand-define-readme: "https://github.com/Financial-Times/o-brand/#obranddefi
     }
     // Validate variables key (an empty map is of type list).
     $variables: map-get($config, 'variables');
+    @if no $variables {
+        @error '#{$error-message}. Config key "variables" is missing. #{$error-message-link}';
+    }
     $supports-variants: map-get($config, 'supports-variants');
+    @if no $supports-variants {
+        @error '#{$error-message}. Config key "supports-variants" is missing. #{$error-message-link}';
+    }
     @if $variables and (type-of($variables) != 'map' and type-of($variables) != 'list' ) {
         @error '#{$error-message}. Config key "variables" should be a map but is of type #{type-of($variables)}. #{$error-message-link}';
     }

--- a/scss/mixins.scss
+++ b/scss/mixins.scss
@@ -149,11 +149,11 @@ $_o-brand-define-readme: "https://github.com/Financial-Times/o-brand/#obranddefi
     }
     // Validate variables key (an empty map is of type list).
     $variables: map-get($config, 'variables');
-    @if no $variables {
+    @if not $variables {
         @error '#{$error-message}. Config key "variables" is missing. #{$error-message-link}';
     }
     $supports-variants: map-get($config, 'supports-variants');
-    @if no $supports-variants {
+    @if not $supports-variants {
         @error '#{$error-message}. Config key "supports-variants" is missing. #{$error-message-link}';
     }
     @if $variables and (type-of($variables) != 'map' and type-of($variables) != 'list' ) {

--- a/test/scss/_fixtures.scss
+++ b/test/scss/_fixtures.scss
@@ -38,6 +38,7 @@ $o-brand: 'internal';
 ));
 
 @include oBrandDefine('o-example', 'whitelabel', (
+	'variables': (),
 	'supports-variants': (
 		'compact'
 	)


### PR DESCRIPTION
Before:
>Error: Cannot set supported variants for component "o-example" and brand "master". Variant "" is invalid. Variant names must be a string.

After:
>Error: "o-example" configuration for brand "master" is invalid. Config key "supports-variants" is missing. Example brand configuration can be seen in the readme: https://github.com/Financial-Times/o-brand/#obranddefine