### PR TITLE
Warn rather than error when config is missing 'variables'.

### DIFF
--- a/scss/_private-functions.scss
+++ b/scss/_private-functions.scss
@@ -17,7 +17,8 @@
 	// Validate variables key (an empty map is of type list).
 	$variables: map-get($config, 'variables');
 	@if not $variables {
-		@return _oBrandError('#{$error-message}. Config key "variables" is missing. #{$error-message-link}');
+		// @breaking Change to an error.
+		@warn '#{$error-message}. Config key "variables" is missing. #{$error-message-link}';
 	}
 	$supports-variants: map-get($config, 'supports-variants');
 	@if not $supports-variants {


### PR DESCRIPTION
This is because older versions of `o-table` trigger this error. The error is quite old, why it didn't error before is still unclear.