### PR TITLE
V2.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ The following mixins and functions help brand a component.
 - [oBrandDefine](#obranddefine) - Define brand configuration (variables & supported variants).
 - [oBrandGet](#obrandget) - Retrieve brand variables.
 - [oBrandSupportsVariant](#obrandsupportsvariant) - Check if the brand supports a variant.
+- [oBrandGetCurrentBrand](#obrandsetcurrentbrand) - Get the chosen brand (defined at product level, or the default 'master' brand)
 
 ### oBrandDefine
 

--- a/scss/mixins.scss
+++ b/scss/mixins.scss
@@ -5,7 +5,8 @@ $_o-brands: () !default; // A map of components to their defined brands.
 $_o-brand-current-component: null !default; // Currently configured component.
 $_o-brand-current-variant: null !default; // Currently configured variant.
 $_o-brand-current-override: null !default; // Currently configured brand config override.
-$_o-brand-default-not-set-warning: false !default; // Has the default not set warning been output.
+$_o-brand-not-set-warning: false !default; // Has a missing brand warning been output.
+$_o-brand-default-not-set-warning: false !default; // Has a missing defualt brand warning been output.
 
 /// Define component configuration for a brand.
 ///
@@ -55,7 +56,8 @@ $_o-brand-default-not-set-warning: false !default; // Has the default not set wa
         @warn "oBrandConfigureFor is deprecated and will be removed in the next major of `o-brand`";
     }
     // The default brand must be configured before o-brand can be used.
-    @if not _oBrandIsDefined($component) {
+    @if not $_o-brand-default-not-set-warning and not _oBrandIsDefined($component) {
+        $_o-brand-default-not-set-warning: true !global;
         @warn 'The default brand "#{$_o-brand-default}" must be defined for "#{$component}".';
     }
     // Validate variant.
@@ -434,13 +436,14 @@ $_o-brand-default-not-set-warning: false !default; // Has the default not set wa
     $component-brands: if(type-of($component-brands) == 'map', $component-brands, ());
     $brand-config: map-get($component-brands, $brand);
     // The default brand must be configured before o-brand can be used.
-    @if not _oBrandIsDefined($component) {
-        @error 'The default brand "#{$_o-brand-default}" must be defined for "#{$component}" before using o-brand.';
+    @if not $_o-brand-default-not-set-warning and not _oBrandIsDefined($component) {
+        $_o-brand-default-not-set-warning: true!global;
+        @warn 'The default brand "#{$_o-brand-default}" must be defined for "#{$component}" before using o-brand.';
     }
     // Validate the requested brand is configured, fallback to the default brand otherwise.
     @if $brand-config == null {
-        @if not $_o-brand-default-not-set-warning and $o-brand-debug-mode == true {
-            $_o-brand-default-not-set-warning: true !global;
+        @if not $_o-brand-not-set-warning and $o-brand-debug-mode == true {
+            $_o-brand-not-set-warning: true !global;
             @warn 'The requested brand "#{$brand}" has not been set. Using "#{$_o-brand-default}" brand instead.';
         }
         @return _oBrandGetConfig($component, $_o-brand-default);

--- a/scss/mixins.scss
+++ b/scss/mixins.scss
@@ -56,7 +56,7 @@ $_o-brand-default-not-set-warning: false !default; // Has the default not set wa
     }
     // The default brand must be configured before o-brand can be used.
     @if not _oBrandIsDefined($component) {
-        @error 'The default brand "#{$_o-brand-default}" must be defined for "#{$component}" before using o-brand.';
+        @warn 'The default brand "#{$_o-brand-default}" must be defined for "#{$component}".';
     }
     // Validate variant.
     @if type-of($variant) != 'list' and type-of($variant) != 'string' and type-of($variant) != 'null' {

--- a/scss/mixins.scss
+++ b/scss/mixins.scss
@@ -178,7 +178,7 @@ $_o-brand-default-not-set-warning: false !default; // Has the default not set wa
         @error '`oBrandGet` expects "$override" to be of type map but was of type "#{type-of($override)}": "#{$override}".';
     }
     // Override config.
-    $brand: if($o-brand, $o-brand, $_o-brand-default);
+    $brand: oBrandGetCurrentBrand();
     @if $override-config {
         $result: _oBrandUpdateConfig($component, $brand, $override-config);
     }
@@ -199,6 +199,11 @@ $_o-brand-default-not-set-warning: false !default; // Has the default not set wa
     @return $values;
 }
 
+/// Get current brand, either the brand specifced by the user or the default (master).
+/// @access public
+@function oBrandGetCurrentBrand() {
+    @return if($o-brand, $o-brand, $_o-brand-default);
+}
 
 // Update currently configured component and variant.
 // If a variant is already set for a component combine them.
@@ -344,7 +349,7 @@ $_o-brand-default-not-set-warning: false !default; // Has the default not set wa
         @error 'Cound not check support for variant #{type-of($variant)} "#{$variant}", expecting a list or string.';
     }
     // Override config.
-    $brand: if($o-brand, $o-brand, $_o-brand-default);
+    $brand: oBrandGetCurrentBrand();
     $original-config: _oBrandGetConfig($component, $brand);
     @if $override {
         $result: _oBrandUpdateConfig($component, $brand, $override);


### PR DESCRIPTION
- Do not error when the master brand is not set. This allows v2 to be compatible with v3.1, enabling the use of a semver range ">=2.2.0 <4".
- Backport "oBrandGetCurrentBrand" function. (added in v3.1.0)

Aim is to make o-brand 2.2.0 compatible with 3.1.0 (">=2.2.0 <4") to fix the build of previous component minors which came before o-brand v3. E.g. `o-header@7.5.2`

I have successfully built  the older version of `o-header` (7.5.2) and  the latest version of `o-buttons` (5.15.0) using this branch.