### PR TITLE
Allow non-whitelabel brands to be customised.

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,8 +211,6 @@ Then call your new function `_oExampleSupports` to determine whether to output C
 
 `oBrandCustomize` allows existing brand variables to be modified, so long as those variables have been defined with `oBrandDefine`. This customisation is component-specific, so a branded component must wrap `oBrandCustomize` within a mixin of its own, as `o-brand` must not be used directly outside Origami components.
 
-Currently only the `whitelabel` brand is allowed to be customised in this way.
-
 Example Component (o-example):
 ```scss
 /// Create a component-specific mixin to wrap `oBrandCustomize`.

--- a/scss/_mixins.scss
+++ b/scss/_mixins.scss
@@ -16,14 +16,13 @@
 }
 
 /// Customise the brand variables for the current brand.
-/// Only the whitelabel brand may be customised.
 ///
 /// @access public
 /// @param {string} $component
 /// @param {map} $variables
 @mixin oBrandCustomize($component, $variables) {
-	@if oBrandGetCurrentBrand() != 'whitelabel' {
-		@error 'Only the whitelabel brand may be customised. To use the whitelabel brand, set the SCSS variable "$o-brand: \'whitelabel\'" before including any Origami components. If you would like to customise a different brand, please discuss your usecase with the Origami team.';
+	@if $o-brand-debug {
+		@debug 'Customising the "#{oBrandGetCurrentBrand()}" brand version of the "#{$component}" component.'; // stylelint-disable-line at-rule-blacklist
 	}
 	// Validate component.
 	$validated-component-name: _oBrandValidateName('Component', $component, 'Cannot customise component "#{$component}"');

--- a/scss/_mixins.scss
+++ b/scss/_mixins.scss
@@ -35,7 +35,7 @@
 		@error 'Could not customise "#{$component}". oBrandCustomize expects variables of type map but found "#{type-of($variables)}".';
 	}
 	@if map-get($variables, 'supports-variants') {
-		@error 'Could not customise "#{$component}". oBrandCustomize expects a map of brand variables to custmoise variants. It is not possible to add or remove support for variants.';
+		@error 'Could not customise "#{$component}". oBrandCustomize expects a map of brand variables to customise variants. It is not possible to add or remove support for variants.';
 	}
 	// Update config.
 	$_o-brands: _oBrandRecursiveMapMerge($_o-brands, ($component: (oBrandGetCurrentBrand(): ('variables': $variables)))) !global;

--- a/scss/_mixins.scss
+++ b/scss/_mixins.scss
@@ -26,9 +26,9 @@
 	}
 	// Validate component.
 	$validated-component-name: _oBrandValidateName('Component', $component, 'Cannot customise component "#{$component}"');
-	$whitelabel-brand-config: _oBrandGetConfig($component, 'whitelabel');
-	@if type-of($whitelabel-brand-config) != 'map' {
-		@error 'Could not customise "#{$component}". Make sure that component supports the whitelabel brand.';
+	$existing-brand-config: _oBrandGetConfig($component, oBrandGetCurrentBrand());
+	@if type-of($existing-brand-config) != 'map' {
+		@error 'Could not customise brand "#{oBrandGetCurrentBrand()}" of the "#{$component}" component. Make sure that component supports the "#{oBrandGetCurrentBrand()}" brand.';
 	}
 	// Variables.
 	@if type-of($variables) != 'map' {

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1,4 +1,10 @@
-$o-brand: null !default; // The chosen current brand.
+/// Set your projects chosen brand.
+$o-brand: null !default;
+
+/// Output extra `debug` notices. For example to see when component brands
+/// are customised.
+$o-brand-debug: false !default;
+
 $_o-brands: () !default; // A map of components to their defined brands.
 $_o-brand-available-brands: ('master', 'internal', 'whitelabel'); // A list of available brands to use for a component
 $_o-brand-default: 'master'; // The fallback current brand.

--- a/test/scss/_mixins.test.scss
+++ b/test/scss/_mixins.test.scss
@@ -73,4 +73,25 @@
 		// Restore brand before test.
 		$o-brand: $origami-set-brand !global;
 	}
+
+	@include test('Modifies a non-whitelabel brand.') {
+		$origami-set-brand: $o-brand;
+		$o-brand: 'master' !global;
+		@include oBrandCustomize('o-example', (
+			'example-background': hotpink
+		));
+		$brand-config: map-get($_o-brands, "o-example");
+		$master-brand-config: map-get($brand-config, "master");
+		@include assert-equal($master-brand-config, (
+			'variables': (
+				example-background: hotpink // example-background is now hotpink
+			),
+			'supports-variants': (
+				'stripe',
+				'compact'
+			)
+		));
+		// Restore brand before test.
+		$o-brand: $origami-set-brand !global;
+	}
 }


### PR DESCRIPTION
This is going to be used first for the about page, which uses
its own non-editorial style, building off the master brand. In the
future this style may be used more widely and brought into Origami
but right now we need to be able to customise the page and experiment.

This PR adds a new debug variable to help us track down where
customisations happen within a project. E.g. if a non-origami package
customises a component and is itself then included in another project
as a dependency.